### PR TITLE
[feat][queue-service] 대기 토큰 Redis Repository 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,19 +51,16 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    implementation 'com.first-ticket:common:0.0.2-SNAPSHOT'
-	runtimeOnly 'org.postgresql:postgresql'
+    implementation 'com.first-ticket:common:0.0.3-SNAPSHOT'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testCompileOnly 'org.projectlombok:lombok'
-	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,10 +56,11 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'com.first-ticket:common:0.0.3-SNAPSHOT'
-
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/firstticket/queueservice/QueueServiceApplication.java
+++ b/src/main/java/com/firstticket/queueservice/QueueServiceApplication.java
@@ -2,8 +2,10 @@ package com.firstticket.queueservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class QueueServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/firstticket/queueservice/config/QueueProperties.java
+++ b/src/main/java/com/firstticket/queueservice/config/QueueProperties.java
@@ -1,0 +1,32 @@
+package com.firstticket.queueservice.config;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+
+/**
+ * queue-service의 운영 정책 설정.
+ * config-repo의 queue-service.yml 에서 외부 주입된다.
+ */
+@Validated
+@ConfigurationProperties(prefix = "queue.token")
+public record QueueProperties(
+
+    /**
+     * 대기 토큰의 TTL
+     * 이 시간 내 입장 승인 못 받으면 자동 만료
+     */
+    @NotNull
+    Duration waitingTtl,
+
+    /**
+     * 한 번의 배치 스케줄러 실행 시 입장 승인할 인원 수
+     */
+    @Min(1)
+    int admissionBatchSize
+
+) {
+}

--- a/src/main/java/com/firstticket/queueservice/domain/QueueToken.java
+++ b/src/main/java/com/firstticket/queueservice/domain/QueueToken.java
@@ -12,9 +12,16 @@ import lombok.Getter;
 import java.util.Objects;
 
 /**
- * 1. 대기 토큰은 발급된 시점에 WAITING 상태로 시작한다
- * 2. WAITING 상태에서만 입장 승인(ADMITTED), 취소(CANCELLED), 만료(EXPIRED)로 전이 가능하다
- * 3. ADMITTED, CANCELLED, EXPIRED 는 최종 상태로 더 이상 전이 불가
+ * 대기 토큰 애그리거트 루트.
+ *
+ * <p>한 사용자의 한 프로그램에 대한 대기 상태를 표현한다.
+ * 발급(WAITING) 후 입장 승인(ADMITTED), 취소(CANCELLED), 만료(EXPIRED) 중 하나로 전이된다.
+ *
+ * <p>상태 전이 규칙:
+ * <ul>
+ *   <li>WAITING → ADMITTED, CANCELLED, EXPIRED</li>
+ *   <li>나머지 상태에서는 전이 불가 (최종 상태)</li>
+ * </ul>
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -81,7 +88,9 @@ public class QueueToken {
         this.status = TokenStatus.EXPIRED;
     }
 
-
+    /**
+     * 현재 상태가 WAITING이 아니면 예외를 던진다.
+     */
     private void ensureWaiting() {
         if (status.isTerminal()) {
             throw new InvalidTokenStateException();

--- a/src/main/java/com/firstticket/queueservice/domain/QueueTokenRepository.java
+++ b/src/main/java/com/firstticket/queueservice/domain/QueueTokenRepository.java
@@ -1,0 +1,48 @@
+package com.firstticket.queueservice.domain;
+
+import com.firstticket.queueservice.domain.vo.ProgramId;
+import com.firstticket.queueservice.domain.vo.QueueTokenId;
+import com.firstticket.queueservice.domain.vo.UserId;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 대기 토큰의 영속성 저장소 추상화
+ * 도메인 계층에서 정의하는 인터페이스로, 인프라 구현(Redis 등)에 무관하다.
+ */
+public interface QueueTokenRepository {
+
+    /**
+     * 대기 토큰을 저장한다 (신규 또는 갱신).
+     */
+    QueueToken save(QueueToken token);
+
+    /**
+     * 토큰 ID로 대기 토큰을 조회한다.
+     */
+    Optional<QueueToken> findById(QueueTokenId id);
+
+    /**
+     * 사용자가 특정 프로그램에 보유한 대기 토큰을 조회한다.
+     * 동일 사용자는 한 프로그램에 하나의 활성 토큰만 가질 수 있다.
+     */
+    Optional<QueueToken> findByUserIdAndProgramId(UserId userId, ProgramId programId);
+
+    /**
+     * 대기 토큰을 삭제한다.
+     */
+    void delete(QueueToken token);
+
+    /**
+     * 사용자가 특정 프로그램의 대기 순번을 조회한다.
+     * 토큰이 없거나 WAITING 상태가 아니면 Optional.empty()
+     */
+    Optional<Long> findRanking(QueueTokenId tokenId, ProgramId programId);
+
+    /**
+     * 특정 프로그램의 다음 입장 승인 대상자들을 조회한다 (앞에서 batchSize 명).
+     */
+    List<QueueToken> findAdmissionCandidates(ProgramId programId, int batchSize);
+
+}

--- a/src/main/java/com/firstticket/queueservice/domain/QueueTokenRepository.java
+++ b/src/main/java/com/firstticket/queueservice/domain/QueueTokenRepository.java
@@ -1,5 +1,6 @@
 package com.firstticket.queueservice.domain;
 
+import com.firstticket.queueservice.domain.exception.DuplicateTokenException;
 import com.firstticket.queueservice.domain.vo.ProgramId;
 import com.firstticket.queueservice.domain.vo.QueueTokenId;
 import com.firstticket.queueservice.domain.vo.UserId;
@@ -8,15 +9,19 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * 대기 토큰의 영속성 저장소 추상화
- * 도메인 계층에서 정의하는 인터페이스로, 인프라 구현(Redis 등)에 무관하다.
+ * 대기 토큰의 영속성 저장소.
+ *
+ * <p>도메인 규칙: 한 사용자는 한 프로그램에 활성 토큰을 하나만 가질 수 있다.
+ * 중복 진입 시도는 인프라 구현체가 거부한다.
  */
 public interface QueueTokenRepository {
 
     /**
-     * 대기 토큰을 저장한다 (신규 또는 갱신).
+     * 신규 대기 토큰을 등록한다.
+     *
+     * @throws DuplicateTokenException 같은 사용자가 이미 같은 프로그램에 토큰 보유 시
      */
-    QueueToken save(QueueToken token);
+    void enqueue(QueueToken token);
 
     /**
      * 토큰 ID로 대기 토큰을 조회한다.
@@ -38,7 +43,7 @@ public interface QueueTokenRepository {
      * 사용자가 특정 프로그램의 대기 순번을 조회한다.
      * 토큰이 없거나 WAITING 상태가 아니면 Optional.empty()
      */
-    Optional<Long> findRanking(QueueTokenId tokenId, ProgramId programId);
+    Optional<Long> findRank(UserId userId, ProgramId programId);
 
     /**
      * 특정 프로그램의 다음 입장 승인 대상자들을 조회한다 (앞에서 batchSize 명).

--- a/src/main/java/com/firstticket/queueservice/domain/TokenStatus.java
+++ b/src/main/java/com/firstticket/queueservice/domain/TokenStatus.java
@@ -1,29 +1,33 @@
 package com.firstticket.queueservice.domain;
 
 /**
- * 대기 토큰의 상태
+ * 대기 토큰의 상태.
  *
- * 상태 전이 규칙:
+ * <p>상태 전이 규칙:
+ * <pre>
  *   WAITING → ADMITTED  (입장 승인)
  *   WAITING → CANCELLED (사용자 취소)
  *   WAITING → EXPIRED   (시간 만료)
  *   ADMITTED, CANCELLED, EXPIRED → (전이 불가, 최종 상태)
+ * </pre>
  */
 public enum TokenStatus {
 
-    // 대기 중
+    /** 대기 중 */
     WAITING,
 
-    // 입장 승인됨
+    /** 입장 승인됨 */
     ADMITTED,
 
-    // 사용자 취소
+    /** 입장 승인됨 */
     CANCELLED,
 
-    // 시간 만료
+    /** 시간 만료 */
     EXPIRED;
 
-    // 전이 불가 여부 반환
+    /**
+     * 최종 상태인지 (더 이상 전이 불가) 여부를 반환한다.
+     */
     public boolean isTerminal() {
         return this != WAITING;
     }

--- a/src/main/java/com/firstticket/queueservice/domain/TokenStatus.java
+++ b/src/main/java/com/firstticket/queueservice/domain/TokenStatus.java
@@ -19,7 +19,7 @@ public enum TokenStatus {
     /** 입장 승인됨 */
     ADMITTED,
 
-    /** 입장 승인됨 */
+    /** 사용자 또는 시스템에 의해 취소됨 */
     CANCELLED,
 
     /** 시간 만료 */

--- a/src/main/java/com/firstticket/queueservice/domain/exception/DuplicateTokenException.java
+++ b/src/main/java/com/firstticket/queueservice/domain/exception/DuplicateTokenException.java
@@ -1,0 +1,9 @@
+package com.firstticket.queueservice.domain.exception;
+
+import com.firstticket.common.exception.BusinessException;
+
+public class DuplicateTokenException extends BusinessException {
+    public DuplicateTokenException() {
+        super(QueueErrorCode.DUPLICATE_TOKEN);
+    }
+}

--- a/src/main/java/com/firstticket/queueservice/domain/exception/InvalidTokenStateException.java
+++ b/src/main/java/com/firstticket/queueservice/domain/exception/InvalidTokenStateException.java
@@ -6,7 +6,7 @@ import com.firstticket.common.response.ErrorCode;
 /**
  * 대기 토큰의 상태 전이 규칙을 위반했을 때 발생하는 예외
  *
- *  예: ADMITTED 상태인 토큰을 cancel() 시도
+ *  <p>예: ADMITTED 상태인 토큰을 cancel() 시도
  */
 public class InvalidTokenStateException extends BusinessException {
 

--- a/src/main/java/com/firstticket/queueservice/domain/exception/QueueErrorCode.java
+++ b/src/main/java/com/firstticket/queueservice/domain/exception/QueueErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum QueueErrorCode implements ErrorCode {
-    INVALID_TOKEN_STATE(HttpStatus.BAD_REQUEST, "대기 토큰 상태 전이 규칙을 위반했습니다");
+    INVALID_TOKEN_STATE(HttpStatus.BAD_REQUEST, "대기 토큰 상태 전이 규칙을 위반했습니다"),
+    DUPLICATE_TOKEN(HttpStatus.CONFLICT, "이미 대기 중인 토큰이 있습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/queueservice/domain/vo/IssuedAt.java
+++ b/src/main/java/com/firstticket/queueservice/domain/vo/IssuedAt.java
@@ -1,16 +1,41 @@
 package com.firstticket.queueservice.domain.vo;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Objects;
 
-public record IssuedAt(LocalDateTime time) {
+/**
+ * 대기 토큰의 발급 시각을 표현하는 VO.
+ *
+ * <p>모든 시간은 UTC 기준으로 다룬다.
+ */
+public record IssuedAt(LocalDateTime value) {
     public IssuedAt {
-        Objects.requireNonNull(time, "IssuedAt은 null일 수 없습니다");
+        Objects.requireNonNull(value, "IssuedAt은 null일 수 없습니다");
     }
 
+    /**
+     * 현재 시각으로 IssuedAt을 생성한다 (UTC 기준).
+     */
     public static IssuedAt now() {
         return new IssuedAt(LocalDateTime.now(ZoneOffset.UTC));
     }
 
+    /**
+     * epoch milli로부터 IssuedAt을 복원한다 (UTC 기준).
+     */
+    public static IssuedAt fromEpochMilli(long epochMilli) {
+        return new IssuedAt(LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(epochMilli),
+                ZoneOffset.UTC
+        ));
+    }
+
+    /**
+     * Redis Sorted Set score 에 사용할 epoch milli 변환.
+     */
+    public long toEpochMilli() {
+        return value.toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
 }

--- a/src/main/java/com/firstticket/queueservice/domain/vo/ProgramId.java
+++ b/src/main/java/com/firstticket/queueservice/domain/vo/ProgramId.java
@@ -3,6 +3,9 @@ package com.firstticket.queueservice.domain.vo;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * 프로그램(공연) ID를 표현하는 VO.
+ */
 public record ProgramId(UUID id) {
 
     public ProgramId {
@@ -17,4 +20,7 @@ public record ProgramId(UUID id) {
         return new ProgramId(UUID.fromString(id));
     }
 
+    public String asString() {
+        return id.toString();
+    }
 }

--- a/src/main/java/com/firstticket/queueservice/domain/vo/QueueTokenId.java
+++ b/src/main/java/com/firstticket/queueservice/domain/vo/QueueTokenId.java
@@ -3,6 +3,9 @@ package com.firstticket.queueservice.domain.vo;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * 대기 토큰 ID를 표현하는 VO.
+ */
 public record QueueTokenId(UUID id) {
 
     public QueueTokenId {
@@ -15,5 +18,9 @@ public record QueueTokenId(UUID id) {
 
     public static QueueTokenId fromString(String id) {
         return new QueueTokenId(UUID.fromString(id));
+    }
+
+    public String asString() {
+        return id.toString();
     }
 }

--- a/src/main/java/com/firstticket/queueservice/domain/vo/UserId.java
+++ b/src/main/java/com/firstticket/queueservice/domain/vo/UserId.java
@@ -3,6 +3,9 @@ package com.firstticket.queueservice.domain.vo;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * 대기 토큰 ID를 표현하는 VO.
+ */
 public record UserId(UUID id) {
 
     public UserId {
@@ -15,5 +18,9 @@ public record UserId(UUID id) {
 
     public static UserId fromString(String id) {
         return new UserId(UUID.fromString(id));
+    }
+
+    public String asString() {
+        return id.toString();
     }
 }

--- a/src/main/java/com/firstticket/queueservice/domain/vo/UserId.java
+++ b/src/main/java/com/firstticket/queueservice/domain/vo/UserId.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * 대기 토큰 ID를 표현하는 VO.
+ * 사용자 ID를 표현하는 VO.
  */
 public record UserId(UUID id) {
 

--- a/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
@@ -1,0 +1,302 @@
+package com.firstticket.queueservice.infrastructure.redis;
+
+import com.firstticket.queueservice.config.QueueProperties;
+import com.firstticket.queueservice.domain.QueueToken;
+import com.firstticket.queueservice.domain.QueueTokenRepository;
+import com.firstticket.queueservice.domain.TokenStatus;
+import com.firstticket.queueservice.domain.exception.DuplicateTokenException;
+import com.firstticket.queueservice.domain.vo.IssuedAt;
+import com.firstticket.queueservice.domain.vo.ProgramId;
+import com.firstticket.queueservice.domain.vo.QueueTokenId;
+import com.firstticket.queueservice.domain.vo.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 대기 토큰의 Redis 기반 영속성 구현체.
+ *
+ * <p>3가지 자료구조를 조합하여 사용한다:
+ * <ul>
+ *   <li>Sorted Set ({@code queue:program:{programId}}) — 대기 순번 관리. score = 진입 시각(epoch milli)</li>
+ *   <li>Hash ({@code queue:token:{tokenId}}) — 토큰 메타 데이터 저장</li>
+ *   <li>String ({@code queue:user:{userId}:program:{programId}}) — 역인덱스 (도메인 키 → 토큰 ID)</li>
+ * </ul>
+ *
+ * <p>저장 시 역인덱스(setIfAbsent)와 트랜잭션(MULTI/EXEC)으로 일관성을 보장한다.
+ * 자세한 흐름은 {@link #enqueue(QueueToken)} 참고.
+ */
+@Repository
+@RequiredArgsConstructor
+public class RedisQueueTokenRepository implements QueueTokenRepository {
+
+    // ===== 키 prefix 상수 =====
+    private static final String QUEUE_KEY_PREFIX = "queue:";
+    private static final String PROGRAM_KEY_PREFIX = "program:";
+    private static final String TOKEN_KEY_PREFIX = "token:";
+    private static final String USER_KEY_PREFIX = "user:";
+
+    // ===== Hash 필드 이름 상수 =====
+    private static final String FIELD_USER_ID = "userId";
+    private static final String FIELD_PROGRAM_ID = "programId";
+    private static final String FIELD_ISSUED_AT = "issuedAt";
+    private static final String FIELD_STATUS = "status";
+
+    private final StringRedisTemplate redisTemplate;
+    private final QueueProperties properties;
+
+    /**
+     * Redis 기반 enqueue 구현.
+     *
+     * <p>2단계 처리:
+     * <ol>
+     *   <li>역인덱스(setIfAbsent)를 락처럼 사용하여 중복 진입 방지</li>
+     *   <li>Sorted Set + Hash 를 MULTI/EXEC 트랜잭션으로 저장</li>
+     * </ol>
+     *
+     * <p>한계: 1단계 성공 후 2단계 실패 시 orphan 역인덱스가 남을 수 있다.
+     * TTL 로 자동 정리되지만, 진짜 원자성을 위해 향후 Lua Script 도입 예정.
+     *
+     * <p>Sorted Set 의 멤버는 키 단위 TTL 불가하므로,
+     * {@link #delete(QueueToken)} 호출 시 명시적 ZREM 으로 정리한다.
+     */
+    @Override
+    public void enqueue(QueueToken token) {
+
+        // 키 생성
+        String programKey = programKey(token.getProgramId());
+        String tokenKey = tokenKey(token.getId());
+        String userProgramKey = userProgramKey(token.getUserId(), token.getProgramId());
+
+        String tokenIdStr = token.getId().asString();
+
+        // Sorted Set의 score로 사용할 진입 시각 (epoch milli)
+        long issuedAtEpochMilli = token.getIssuedAt().toEpochMilli();
+
+        Duration ttl = properties.waitingTtl();
+
+        // 1단계: 역인덱스를 락처럼 사용하여 중복 진입 방지
+        Boolean acquired = redisTemplate.opsForValue()
+            .setIfAbsent(userProgramKey, tokenIdStr, ttl);
+
+        if (!Boolean.TRUE.equals(acquired)) {
+            throw new DuplicateTokenException();
+        }
+
+        // 2단계: 나머지 키를 트랜잭션으로 저장
+        Map<String, String> tokenFields = Map.of(
+            FIELD_USER_ID, token.getUserId().asString(),
+            FIELD_PROGRAM_ID, token.getProgramId().asString(),
+            FIELD_ISSUED_AT, String.valueOf(issuedAtEpochMilli),
+            FIELD_STATUS, token.getStatus().name()
+        );
+
+        // 트랜잭션으로 Sorted Set + Hash 저장 + Hash TTL 설정
+        redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @SuppressWarnings({"unchecked"})
+            @Override
+            public List<Object> execute(RedisOperations operations) {
+                operations.multi();
+
+                // 1. Sorted Set: 대기열에 추가 (score = 진입 시각)
+                operations.opsForZSet().add(programKey, tokenIdStr, issuedAtEpochMilli);
+
+                // 2. Hash: 토큰 메타 데이터 저장
+                operations.opsForHash().putAll(tokenKey, tokenFields);
+
+                // 3. Hash 키에 TTL 설정 (Sorted Set은 컬렉션이라 별도 정리 필요)
+                operations.expire(tokenKey, ttl);
+
+                return operations.exec();
+            }
+        });
+    }
+
+    /**
+     * Redis 기반 findById 구현.
+     *
+     * <p>Hash 전체 조회 후 도메인 객체로 복원한다.
+     * 토큰이 없으면 빈 Map이 반환되며 (null 아님), Optional.empty()로 처리한다.
+     */
+    @Override
+    public Optional<QueueToken> findById(QueueTokenId id) {
+        String tokenKey = tokenKey(id);
+
+        // 타입 명시한 Map 으로 받기 위해 hashOps 변수 사용
+        HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
+        // Redis 에서 Hash 전체 조회
+        Map<String, String> entries = hashOps.entries(tokenKey);
+
+        // 토큰 없으면 빈 Map 이 옴 (null 아님)
+        if (entries.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Hash 데이터로 QueueToken 객체 만들어서 반환
+        return Optional.of(toQueueToken(id, entries));
+    }
+
+    /**
+     * Redis Hash 데이터로부터 QueueToken 도메인 객체를 복원한다.
+     */
+    private QueueToken toQueueToken(QueueTokenId id, Map<String, String> entries) {
+        UserId userId = UserId.fromString(entries.get(FIELD_USER_ID));
+        ProgramId programId = ProgramId.fromString(entries.get(FIELD_PROGRAM_ID));
+        IssuedAt issuedAt = IssuedAt.fromEpochMilli(Long.parseLong(entries.get(FIELD_ISSUED_AT)));
+        TokenStatus status = TokenStatus.valueOf(entries.get(FIELD_STATUS));
+
+        return QueueToken.restore(id, userId, programId, issuedAt, status);
+    }
+
+    /**
+     * Redis 기반 findById 구현.
+     *
+     * <p>Hash 전체 조회 후 도메인 객체로 복원한다.
+     * 토큰이 없으면 빈 Map이 반환되며 (null 아님), Optional.empty()로 처리한다.
+     */
+    @Override
+    public Optional<QueueToken> findByUserIdAndProgramId(UserId userId, ProgramId programId) {
+        String userProgramKey = userProgramKey(userId, programId);
+
+        // 1단계: 역인덱스로 tokenId 조회
+        String tokenIdStr = redisTemplate.opsForValue().get(userProgramKey);
+
+        if (tokenIdStr == null) {
+            return Optional.empty();
+        }
+
+        // 2단계: tokenId로 토큰 전체 조회 (findById 재사용)
+        return findById(QueueTokenId.fromString(tokenIdStr));
+    }
+
+    /**
+     * Redis 기반 delete 구현.
+     *
+     * <p>3개 키를 트랜잭션으로 묶어 삭제한다:
+     * <ol>
+     *   <li>Sorted Set 에서 토큰 멤버 제거 (ZREM)</li>
+     *   <li>Hash 키 삭제</li>
+     *   <li>역인덱스 키 삭제</li>
+     * </ol>
+     *
+     * <p>이미 만료/삭제된 토큰에 대해서도 안전하게 호출 가능 (멱등).
+     */
+    @Override
+    public void delete(QueueToken token) {
+        String programKey = programKey(token.getProgramId());
+        String tokenKey = tokenKey(token.getId());
+        String userProgramKey = userProgramKey(token.getUserId(), token.getProgramId());
+        String tokenIdStr = token.getId().asString();
+
+        redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @SuppressWarnings({"unchecked"})
+            @Override
+            public List<Object> execute(RedisOperations operations) {
+                operations.multi();
+
+                // 1. Sorted Set 에서 멤버 제거
+                operations.opsForZSet().remove(programKey, tokenIdStr);
+
+                // 2. Hash 키 삭제
+                operations.delete(tokenKey);
+
+                // 3. 역인덱스 키 삭제
+                operations.delete(userProgramKey);
+
+                return operations.exec();
+            }
+        });
+    }
+
+    /**
+     * Redis 기반 findRank 구현.
+     *
+     * <p>2단계 조회:
+     * <ol>
+     *   <li>역인덱스로 tokenId 조회</li>
+     *   <li>Sorted Set의 ZRANK로 순번 조회</li>
+     * </ol>
+     *
+     * <p>Redis ZRANK는 0-based이므로 사용자에게 보여줄 1-based로 변환한다.
+     */
+    @Override
+    public Optional<Long> findRank(UserId userId, ProgramId programId) {
+        String userProgramKey = userProgramKey(userId, programId);
+
+        // 1단계: 역인덱스로 tokenId 조회
+        String tokenIdStr = redisTemplate.opsForValue().get(userProgramKey);
+
+        if (tokenIdStr == null) {
+            return Optional.empty();
+        }
+
+        // 2단계: Sorted Set에서 순번 조회 (0-based)
+        String programKey = programKey(programId);
+        Long rank = redisTemplate.opsForZSet().rank(programKey, tokenIdStr);
+
+        if (rank == null) {
+            return Optional.empty();
+        }
+
+        // 3단계: 1-based로 변환하여 반환
+        return Optional.of(rank + 1);
+    }
+
+    /**
+     * Redis 기반 findAdmissionCandidates 구현.
+     *
+     * <p>2단계 조회:
+     * <ol>
+     *   <li>Sorted Set ZRANGE로 앞에서 batchSize개의 tokenId 추출</li>
+     *   <li>각 tokenId로 토큰 전체 조회 (N번 Hash 조회)</li>
+     * </ol>
+     *
+     * <p>Hash가 만료되어 토큰을 복원할 수 없는 orphan 케이스는 자연 필터링된다.
+     * 향후 N번 조회를 단일 Lua Script로 통합 검토.
+     */
+    @Override
+    public List<QueueToken> findAdmissionCandidates(ProgramId programId, int batchSize) {
+        String programKey = programKey(programId);
+
+        // 1단계: Sorted Set에서 앞에서부터 batchSize명의 tokenId 조회
+        Set<String> tokenIds = redisTemplate.opsForZSet().range(programKey, 0, batchSize - 1);
+
+        if (tokenIds == null || tokenIds.isEmpty()) {
+            return List.of();
+        }
+
+        // 2단계: 각 tokenId로 토큰 전체 조회
+        return tokenIds.stream()
+            // String → Optional<QueueToken>
+            .map(tokenIdStr -> findById(QueueTokenId.fromString(tokenIdStr)))
+            // 토큰 있는 것만
+            .filter(Optional::isPresent)
+            // Optional<QueueToken> → QueueToken
+            .map(Optional::get)
+            .toList();
+    }
+
+    // ===== 키 생성 헬퍼 =====
+
+    private String programKey(ProgramId programId) {
+        return QUEUE_KEY_PREFIX + PROGRAM_KEY_PREFIX + programId.asString();
+    }
+
+    private String tokenKey(QueueTokenId tokenId) {
+        return QUEUE_KEY_PREFIX + TOKEN_KEY_PREFIX + tokenId.asString();
+    }
+
+    private String userProgramKey(UserId userId, ProgramId programId) {
+        return QUEUE_KEY_PREFIX + USER_KEY_PREFIX + userId.asString()
+            + ":" + PROGRAM_KEY_PREFIX + programId.asString();
+    }
+}

--- a/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
@@ -269,6 +269,10 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
      */
     @Override
     public List<QueueToken> findAdmissionCandidates(ProgramId programId, int batchSize) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize는 1 이상이어야 합니다: " + batchSize);
+        }
+
         String programKey = programKey(programId);
 
         // 1단계: Sorted Set에서 앞에서부터 batchSize명의 tokenId 조회

--- a/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
@@ -197,6 +197,13 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
         String userProgramKey = userProgramKey(token.getUserId(), token.getProgramId());
         String tokenIdStr = token.getId().asString();
 
+        // 역인덱스 값과 토큰 ID가 일치할 때만 삭제
+        // (다른 토큰이 차지한 경우는 그대로 둠 — race condition 방어)
+        String current = redisTemplate.opsForValue().get(userProgramKey);
+        if (tokenIdStr.equals(current)) {
+            redisTemplate.delete(userProgramKey);
+        }
+
         redisTemplate.execute(new SessionCallback<List<Object>>() {
             @SuppressWarnings({"unchecked"})
             @Override
@@ -208,9 +215,6 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
 
                 // 2. Hash 키 삭제
                 operations.delete(tokenKey);
-
-                // 3. 역인덱스 키 삭제
-                operations.delete(userProgramKey);
 
                 return operations.exec();
             }

--- a/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
@@ -10,6 +10,7 @@ import com.firstticket.queueservice.domain.vo.ProgramId;
 import com.firstticket.queueservice.domain.vo.QueueTokenId;
 import com.firstticket.queueservice.domain.vo.UserId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.SessionCallback;
@@ -35,6 +36,7 @@ import java.util.Set;
  * <p>저장 시 역인덱스(setIfAbsent)와 트랜잭션(MULTI/EXEC)으로 일관성을 보장한다.
  * 자세한 흐름은 {@link #enqueue(QueueToken)} 참고.
  */
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class RedisQueueTokenRepository implements QueueTokenRepository {
@@ -141,8 +143,14 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
             return Optional.empty();
         }
 
-        // Hash 데이터로 QueueToken 객체 만들어서 반환
-        return Optional.of(toQueueToken(id, entries));
+        // 깨진 레코드 자동 정리 향후 도입
+        try {
+            // Hash 데이터로 QueueToken 객체 만들어서 반환
+            return Optional.of(toQueueToken(id, entries));
+        } catch (Exception e) {
+            log.warn("깨진 Hash 레코드 발견. tokenId={}", id.asString(), e);
+            return Optional.empty();
+        }
     }
 
     /**
@@ -158,10 +166,13 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
     }
 
     /**
-     * Redis 기반 findById 구현.
+     * Redis 기반 findByUserIdAndProgramId 구현.
      *
-     * <p>Hash 전체 조회 후 도메인 객체로 복원한다.
-     * 토큰이 없으면 빈 Map이 반환되며 (null 아님), Optional.empty()로 처리한다.
+     * <p>2단계 조회:
+     * <ol>
+     *   <li>역인덱스로 tokenId 조회</li>
+     *   <li>tokenId로 토큰 전체 조회 ({@link #findById} 재사용)</li>
+     * </ol>
      */
     @Override
     public Optional<QueueToken> findByUserIdAndProgramId(UserId userId, ProgramId programId) {

--- a/src/test/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepositoryTest.java
+++ b/src/test/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepositoryTest.java
@@ -260,6 +260,30 @@ class RedisQueueTokenRepositoryTest {
             // enqueue 없이 바로 delete
             repository.delete(token);   // 예외 없어야 함
         }
+
+        @Test
+        @DisplayName("역인덱스가 다른 토큰을 가리키면 역인덱스는 유지된다 (race 방어)")
+        void 역인덱스_compare_and_delete() {
+            UserId userId = UserId.of(UUID.randomUUID());
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+
+            // 1. tokenA 발급 후 강제 삭제 (Sorted Set, Hash, 역인덱스 모두 사라짐)
+            QueueToken tokenA = QueueToken.issue(userId, programId);
+            repository.enqueue(tokenA);
+
+            // 2. 같은 사용자가 tokenB 로 재진입 (역인덱스 = tokenB)
+            repository.delete(tokenA);
+            QueueToken tokenB = QueueToken.issue(userId, programId);
+            repository.enqueue(tokenB);
+
+            // 3. 늦게 도착한 tokenA 의 delete (race 시뮬)
+            repository.delete(tokenA);
+
+            // 4. tokenB 의 역인덱스는 그대로 — findByUserIdAndProgramId 로 tokenB 조회 가능
+            Optional<QueueToken> found = repository.findByUserIdAndProgramId(userId, programId);
+            assertThat(found).isPresent();
+            assertThat(found.get().getId()).isEqualTo(tokenB.getId());
+        }
     }
 
     @Nested

--- a/src/test/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepositoryTest.java
+++ b/src/test/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepositoryTest.java
@@ -1,0 +1,321 @@
+package com.firstticket.queueservice.infrastructure.redis;
+
+import com.firstticket.queueservice.domain.QueueToken;
+import com.firstticket.queueservice.domain.TokenStatus;
+import com.firstticket.queueservice.domain.exception.DuplicateTokenException;
+import com.firstticket.queueservice.domain.vo.ProgramId;
+import com.firstticket.queueservice.domain.vo.UserId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * RedisQueueTokenRepository 통합 테스트.
+ *
+ * <p>Testcontainers로 실제 Redis를 띄워 테스트한다.
+ * 매 테스트 후 flushAll로 데이터를 초기화하여 격리를 보장한다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+class RedisQueueTokenRepositoryTest {
+
+    @Container
+    @ServiceConnection(name = "redis")
+    @SuppressWarnings("resource")
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+        .withExposedPorts(6379);
+
+    @Autowired
+    private RedisQueueTokenRepository repository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @AfterEach
+    void cleanUp() {
+        redisTemplate.execute((RedisCallback<Object>) connection -> {
+            connection.serverCommands().flushAll();
+            return null;
+        });
+    }
+
+    @Nested
+    @DisplayName("enqueue")
+    class Enqueue {
+
+        @Test
+        @DisplayName("새 토큰을 등록하면 조회할 수 있다")
+        void 새_토큰_등록() {
+            QueueToken token = newToken();
+
+            repository.enqueue(token);
+
+            Optional<QueueToken> found = repository.findById(token.getId());
+            assertThat(found).isPresent();
+            assertThat(found.get().getStatus()).isEqualTo(TokenStatus.WAITING);
+            assertThat(found.get().getUserId()).isEqualTo(token.getUserId());
+            assertThat(found.get().getProgramId()).isEqualTo(token.getProgramId());
+        }
+
+        @Test
+        @DisplayName("같은 사용자가 같은 프로그램에 중복 진입 시 DuplicateTokenException 발생")
+        void 중복_진입_예외() {
+            UserId userId = UserId.of(UUID.randomUUID());
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+
+            QueueToken first = QueueToken.issue(userId, programId);
+            repository.enqueue(first);
+
+            QueueToken second = QueueToken.issue(userId, programId);
+            assertThatThrownBy(() -> repository.enqueue(second))
+                .isInstanceOf(DuplicateTokenException.class);
+        }
+
+        @Test
+        @DisplayName("같은 사용자라도 다른 프로그램이면 진입 가능")
+        void 다른_프로그램_진입() {
+            UserId userId = UserId.of(UUID.randomUUID());
+
+            QueueToken first = QueueToken.issue(userId, ProgramId.of(UUID.randomUUID()));
+            QueueToken second = QueueToken.issue(userId, ProgramId.of(UUID.randomUUID()));
+
+            repository.enqueue(first);
+            repository.enqueue(second);
+
+            assertThat(repository.findById(first.getId())).isPresent();
+            assertThat(repository.findById(second.getId())).isPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findById")
+    class FindById {
+
+        @Test
+        @DisplayName("저장된 토큰의 모든 필드가 정확히 복원된다")
+        void 토큰_필드_복원() {
+            QueueToken token = newToken();
+            repository.enqueue(token);
+
+            QueueToken found = repository.findById(token.getId()).orElseThrow();
+
+            assertThat(found.getId()).isEqualTo(token.getId());
+            assertThat(found.getUserId()).isEqualTo(token.getUserId());
+            assertThat(found.getProgramId()).isEqualTo(token.getProgramId());
+            assertThat(found.getStatus()).isEqualTo(token.getStatus());
+        }
+
+        @Test
+        @DisplayName("저장 안 된 ID는 빈 Optional 반환")
+        void 미저장_ID() {
+            Optional<QueueToken> found = repository.findById(
+                com.firstticket.queueservice.domain.vo.QueueTokenId.of()
+            );
+
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserIdAndProgramId")
+    class FindByUserIdAndProgramId {
+
+        @Test
+        @DisplayName("저장된 사용자 토큰을 조회할 수 있다")
+        void 저장된_토큰_조회() {
+            UserId userId = UserId.of(UUID.randomUUID());
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+            QueueToken token = QueueToken.issue(userId, programId);
+            repository.enqueue(token);
+
+            Optional<QueueToken> found = repository.findByUserIdAndProgramId(userId, programId);
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getId()).isEqualTo(token.getId());
+        }
+
+        @Test
+        @DisplayName("저장 안 된 사용자는 빈 Optional 반환")
+        void 미저장_사용자() {
+            Optional<QueueToken> found = repository.findByUserIdAndProgramId(
+                UserId.of(UUID.randomUUID()),
+                ProgramId.of(UUID.randomUUID())
+            );
+
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findRank")
+    class FindRank {
+
+        @Test
+        @DisplayName("첫 번째 진입자의 순번은 1이다")
+        void 첫_번째_진입자() {
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+            UserId userId = UserId.of(UUID.randomUUID());
+
+            QueueToken token = QueueToken.issue(userId, programId);
+            repository.enqueue(token);
+
+            Optional<Long> rank = repository.findRank(userId, programId);
+
+            assertThat(rank).isPresent();
+            assertThat(rank.get()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("두 번째 진입자의 순번은 2이다")
+        void 두_번째_진입자() throws InterruptedException {
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+
+            QueueToken first = QueueToken.issue(UserId.of(UUID.randomUUID()), programId);
+            repository.enqueue(first);
+
+            // epoch milli 차이 보장 (Sorted Set score 충돌 방지)
+            Thread.sleep(2);
+
+            UserId secondUser = UserId.of(UUID.randomUUID());
+            QueueToken second = QueueToken.issue(secondUser, programId);
+            repository.enqueue(second);
+
+            Optional<Long> rank = repository.findRank(secondUser, programId);
+
+            assertThat(rank).isPresent();
+            assertThat(rank.get()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("미진입 사용자는 빈 Optional 반환")
+        void 미진입_사용자() {
+            Optional<Long> rank = repository.findRank(
+                UserId.of(UUID.randomUUID()),
+                ProgramId.of(UUID.randomUUID())
+            );
+
+            assertThat(rank).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    class Delete {
+
+        @Test
+        @DisplayName("삭제하면 모든 키에서 조회되지 않는다")
+        void 삭제_후_조회_불가() {
+            QueueToken token = newToken();
+            repository.enqueue(token);
+
+            repository.delete(token);
+
+            assertThat(repository.findById(token.getId())).isEmpty();
+            assertThat(repository.findByUserIdAndProgramId(
+                token.getUserId(), token.getProgramId())).isEmpty();
+            assertThat(repository.findRank(
+                token.getUserId(), token.getProgramId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("삭제 후 같은 사용자가 재진입 가능 (DuplicateTokenException X)")
+        void 삭제_후_재진입() {
+            UserId userId = UserId.of(UUID.randomUUID());
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+
+            QueueToken first = QueueToken.issue(userId, programId);
+            repository.enqueue(first);
+            repository.delete(first);
+
+            QueueToken second = QueueToken.issue(userId, programId);
+            repository.enqueue(second);   // 예외 발생 안 해야 함
+
+            assertThat(repository.findByUserIdAndProgramId(userId, programId))
+                .isPresent();
+        }
+
+        @Test
+        @DisplayName("이미 없는 토큰을 삭제해도 예외 없음 (멱등)")
+        void 멱등성() {
+            QueueToken token = newToken();
+
+            // enqueue 없이 바로 delete
+            repository.delete(token);   // 예외 없어야 함
+        }
+    }
+
+    @Nested
+    @DisplayName("findAdmissionCandidates")
+    class FindAdmissionCandidates {
+
+        @Test
+        @DisplayName("앞에서 batchSize명을 진입 시각 순으로 반환")
+        void 앞_N명_조회() throws InterruptedException {
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+
+            QueueToken first = QueueToken.issue(UserId.of(UUID.randomUUID()), programId);
+            repository.enqueue(first);
+            Thread.sleep(2);
+
+            QueueToken second = QueueToken.issue(UserId.of(UUID.randomUUID()), programId);
+            repository.enqueue(second);
+            Thread.sleep(2);
+
+            QueueToken third = QueueToken.issue(UserId.of(UUID.randomUUID()), programId);
+            repository.enqueue(third);
+
+            List<QueueToken> candidates = repository.findAdmissionCandidates(programId, 2);
+
+            assertThat(candidates).hasSize(2);
+            assertThat(candidates.get(0).getId()).isEqualTo(first.getId());
+            assertThat(candidates.get(1).getId()).isEqualTo(second.getId());
+        }
+
+        @Test
+        @DisplayName("토큰이 없으면 빈 리스트 반환")
+        void 빈_프로그램() {
+            List<QueueToken> candidates = repository.findAdmissionCandidates(
+                ProgramId.of(UUID.randomUUID()), 10);
+
+            assertThat(candidates).isEmpty();
+        }
+
+        @Test
+        @DisplayName("batchSize가 실제 인원보다 크면 있는 만큼 반환")
+        void 적은_인원() {
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+
+            QueueToken token = QueueToken.issue(UserId.of(UUID.randomUUID()), programId);
+            repository.enqueue(token);
+
+            List<QueueToken> candidates = repository.findAdmissionCandidates(programId, 100);
+
+            assertThat(candidates).hasSize(1);
+        }
+    }
+
+    private QueueToken newToken() {
+        return QueueToken.issue(
+            UserId.of(UUID.randomUUID()),
+            ProgramId.of(UUID.randomUUID())
+        );
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,15 +4,12 @@ spring:
       enabled: false
   config:
     import: ""
-  datasource:
-    url: jdbc:h2:mem:test
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
 
 eureka:
   client:
     enabled: false
+
+queue:
+  token:
+    waiting-ttl: PT30M
+    admission-batch-size: 100


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

queue-service에 Redis 기반 대기 토큰 영속성 구현체와 통합 테스트를 추가했습니다.

3가지 자료구조(Sorted Set + Hash + 역인덱스)를 조합하여 대기열 핵심 동작을 효율적으로 처리합니다. setIfAbsent와 MULTI/EXEC 트랜잭션으로 일관성을 보장하며, 실제 Redis를 띄우는 Testcontainers로 운영 환경과 동일하게 검증합니다.

- QueueTokenRepository 인터페이스 (도메인 계층)
- RedisQueueTokenRepository 구현체 (인프라 계층)
- QueueProperties (`@ConfigurationProperties`)
- DuplicateTokenException + ErrorCode 추가
- IssuedAt VO에 epoch milli 변환 메서드 추가
- VO 4개에 asString() 추가
- Testcontainers 통합 테스트 16개
- 자잘한 주석 수정


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)

close #4 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)

### Redis 자료구조 설계
- **Sorted Set** (`queue:program:{programId}`): 대기 순번. score = 진입 시각 (epoch milli)
- **Hash** (`queue:token:{tokenId}`): 토큰 메타 데이터
- **String** (`queue:user:{userId}:program:{programId}`): 역인덱스 (도메인 키 → 토큰 ID)

### 일관성 보장
- **enqueue**: setIfAbsent로 중복 진입 방지 → MULTI/EXEC로 나머지 저장
- **delete**: 3개 키 모두 트랜잭션으로 삭제
- **TTL**: Hash와 역인덱스는 30분 TTL, Sorted Set 멤버는 명시적 삭제

### 도메인 규칙
- 한 사용자는 한 프로그램에 활성 토큰을 하나만 보유 (DuplicateTokenException)
- ADMITTED/CANCELLED/EXPIRED 시 즉시 Hard Delete (queue-service는 대기 중인 토큰만 관리)

### 향후 도입 검토 (별도 이슈)
- Lua Script: 진짜 원자성 (현재 setIfAbsent + 트랜잭션의 부분 실패 한계 해결)
- DB 영구 저장: 운영 메트릭(Q-11), 어뷰징 차단(Q-12) 시 RDB 도입 예정
- Score 정확도: 동시 진입 시 score 충돌 시 INCR 시퀀스 추가 검토


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 대기열 중복 토큰 방지(중복 시 409 응답) 추가
  * 대기열 운영 정책 설정 추가(대기 TTL, 입장 배치 크기)
  * Redis 기반 대기열 저장소 도입 — 대기 순위 조회 및 입장 후보 조회 지원

* **테스트**
  * Redis(Testcontainers)를 이용한 통합 테스트 추가 및 강화

* **기타**
  * 내부 라이브러리 버전 업데이트 및 문서·오류 메시지 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->