### PR TITLE
[feat][queue-service] 대기열 API 통합 테스트 + REST Docs 문서 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,6 @@ gradle-app.setting
 .env
 .env.*
 !.env.example
+
+# REST Docs 빌드 결과
+src/main/resources/static/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.13'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.first-ticket'
@@ -11,6 +12,10 @@ java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)
 	}
+}
+
+configurations {
+	asciidoctorExt
 }
 
 def env = [:]
@@ -45,6 +50,7 @@ repositories {
 }
 
 ext {
+	set('snippetsDir', file("build/generated-snippets"))
 	set('springCloudVersion', "2025.0.2")
 }
 
@@ -61,6 +67,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
@@ -73,5 +81,36 @@ dependencyManagement {
 }
 
 tasks.named('test') {
+	outputs.dir snippetsDir
 	useJUnitPlatform()
+}
+
+asciidoctor {
+	inputs.dir snippetsDir
+	dependsOn test
+	configurations 'asciidoctorExt'
+	baseDirFollowsSourceFile()
+}
+
+tasks.named('asciidoctor') {
+	doFirst {
+		delete file('src/main/resources/static/docs')
+	}
+}
+
+tasks.register('copyDocument', Copy) { // 생성된 html 파일을 옮긴다
+	dependsOn asciidoctor // Gradle의 asciidoctor Task 이후 수행
+	from layout.buildDirectory.dir("docs/asciidoc")
+	into layout.projectDirectory.dir("src/main/resources/static/docs")
+}
+
+tasks.named('build') {
+	dependsOn copyDocument
+}
+
+bootJar {
+	dependsOn asciidoctor
+	from(layout.buildDirectory.dir("docs/asciidoc")) {
+		into 'static/docs'
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ dependencyManagement {
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+	systemProperty 'spring.cloud.config.enabled', 'false'
 }
 
 asciidoctor {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,81 @@
+= 대기열 API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+
+== 개요
+
+대기열 진입 / 조회 / 취소 API.
+
+=== 인증
+
+모든 API 는 Gateway 가 검증한 `X-User-Id` 헤더를 사용한다.
+
+=== 응답 형식
+
+성공 / 실패 모두 `ApiResponse<T>` 형식으로 응답한다.
+
+[source,json]
+----
+{
+  "success": true,
+  "code": "QUEUE_TOKEN_ISSUED",
+  "message": "대기 토큰이 발급되었습니다",
+  "timestamp": "2026-04-30T12:00:00",
+  "data": {
+    "tokenId": "...",
+    "status": "WAITING",
+    "issuedAt": "...",
+    "position": 50
+  }
+}
+----
+
+== 공통 에러 응답
+
+=== 인증 실패 (401)
+
+`X-User-Id` 헤더가 없거나 형식이 잘못된 경우 발생한다.
+
+include::{snippets}/queue-token-unauthorized/http-response.adoc[]
+include::{snippets}/queue-token-unauthorized/response-fields.adoc[]
+
+== 대기열 진입
+
+operation::queue-token-issue[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+== 대기 정보 조회
+
+operation::queue-token-get[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+=== 에러 응답
+
+==== 토큰 없음 (404)
+
+해당 사용자의 토큰이 없을 때 발생한다.
+
+include::{snippets}/queue-token-get-not-found/http-response.adoc[]
+include::{snippets}/queue-token-get-not-found/response-fields.adoc[]
+
+== 대기 취소
+
+operation::queue-token-cancel[snippets='http-request,path-parameters,request-headers,http-response']
+
+=== 에러 응답
+
+==== 토큰 없음 (404)
+
+해당 사용자의 토큰이 없을 때 발생한다.
+
+include::{snippets}/queue-token-cancel-not-found/http-response.adoc[]
+include::{snippets}/queue-token-cancel-not-found/response-fields.adoc[]
+
+==== 취소 불가 상태 (400)
+
+WAITING 이 아닌 상태 (예: ADMITTED) 에서 취소를 시도할 때 발생한다.
+
+include::{snippets}/queue-token-cancel-invalid-state/http-response.adoc[]
+include::{snippets}/queue-token-cancel-invalid-state/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -47,6 +47,15 @@ include::{snippets}/queue-token-unauthorized/response-fields.adoc[]
 
 operation::queue-token-issue[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
+=== 에러 응답
+
+==== 동시 진입 race (409)
+
+동시 요청으로 race condition 발생 시 (드문 케이스). v0.2.0 의 Lua Script 통합으로 근본 해결 예정.
+
+include::{snippets}/queue-token-duplicate/http-response.adoc[]
+include::{snippets}/queue-token-duplicate/response-fields.adoc[]
+
 == 대기 정보 조회
 
 operation::queue-token-get[snippets='http-request,path-parameters,request-headers,http-response,response-fields']

--- a/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
+++ b/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
@@ -1,0 +1,293 @@
+package com.firstticket.queueservice.presentation;
+
+import com.firstticket.common.exception.BusinessException;
+import com.firstticket.common.exception.GlobalExceptionHandler;
+import com.firstticket.common.response.CommonErrorCode;
+import com.firstticket.common.web.AuthContext;
+import com.firstticket.queueservice.application.QueueTokenService;
+import com.firstticket.queueservice.application.dto.QueueTokenResult;
+import com.firstticket.queueservice.domain.QueueToken;
+import com.firstticket.queueservice.domain.exception.InvalidTokenStateException;
+import com.firstticket.queueservice.domain.exception.TokenNotFoundException;
+import com.firstticket.queueservice.domain.vo.ProgramId;
+import com.firstticket.queueservice.domain.vo.UserId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(QueueTokenController.class)
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@Import(GlobalExceptionHandler.class)
+class QueueTokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private QueueTokenService queueTokenService;
+
+    // ===== 성공 케이스 =====
+
+    @Test
+    @DisplayName("대기열 진입 성공")
+    void 대기열_진입_성공() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID programId = UUID.randomUUID();
+        QueueToken token = QueueToken.issue(UserId.of(userId), ProgramId.of(programId));
+        QueueTokenResult result = QueueTokenResult.of(token, 1L);
+
+        when(queueTokenService.issueToken(any())).thenReturn(result);
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId).thenReturn(userId);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId)
+                    .header("X-User-Id", userId.toString()))
+                .andExpect(status().isCreated())
+                .andDo(document("queue-token-issue",
+                    preprocessRequest(
+                        prettyPrint(),
+                        modifyHeaders().remove("Content-Type")
+                    ),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("programId").description("프로그램 ID")
+                    ),
+                    requestHeaders(
+                        headerWithName("X-User-Id").description("Gateway 가 주입한 사용자 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부"),
+                        fieldWithPath("code").description("응답 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각"),
+                        fieldWithPath("data.tokenId").description("발급된 토큰 ID"),
+                        fieldWithPath("data.status").description("토큰 상태 (WAITING)"),
+                        fieldWithPath("data.issuedAt").description("발급 시각"),
+                        fieldWithPath("data.position").description("현재 순번")
+                    )
+                ));
+        }
+    }
+
+    @Test
+    @DisplayName("대기 정보 조회 성공")
+    void 대기_정보_조회_성공() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID programId = UUID.randomUUID();
+        QueueToken token = QueueToken.issue(UserId.of(userId), ProgramId.of(programId));
+        QueueTokenResult result = QueueTokenResult.of(token, 50L);
+
+        when(queueTokenService.getToken(any())).thenReturn(result);
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId).thenReturn(userId);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
+                    .header("X-User-Id", userId.toString()))
+                .andExpect(status().isOk())
+                .andDo(document("queue-token-get",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("programId").description("프로그램 ID")
+                    ),
+                    requestHeaders(
+                        headerWithName("X-User-Id").description("Gateway 가 주입한 사용자 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부"),
+                        fieldWithPath("code").description("응답 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각"),
+                        fieldWithPath("data.tokenId").description("토큰 ID"),
+                        fieldWithPath("data.status").description("토큰 상태 (WAITING / ADMITTED / EXPIRED)"),
+                        fieldWithPath("data.issuedAt").description("발급 시각"),
+                        fieldWithPath("data.position").description("현재 순번. ADMITTED 등 큐에서 빠진 상태면 null").optional()
+                    )
+                ));
+        }
+    }
+
+    @Test
+    @DisplayName("대기 취소 성공")
+    void 대기_취소_성공() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID programId = UUID.randomUUID();
+
+        doNothing().when(queueTokenService).cancelToken(any());
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId).thenReturn(userId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
+                    .header("X-User-Id", userId.toString()))
+                .andExpect(status().isNoContent())
+                .andDo(document("queue-token-cancel",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("programId").description("프로그램 ID")
+                    ),
+                    requestHeaders(
+                        headerWithName("X-User-Id").description("Gateway 가 주입한 사용자 ID")
+                    )
+                ));
+        }
+    }
+
+    // ===== 에러 케이스 =====
+
+    @Test
+    @DisplayName("X-User-Id 헤더 없으면 401 Unauthorized")
+    void 인증_실패_401() throws Exception {
+        // given
+        UUID programId = UUID.randomUUID();
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId)
+                .thenThrow(new BusinessException(CommonErrorCode.UNAUTHORIZED));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("queue-token-unauthorized",
+                    preprocessRequest(
+                        prettyPrint(),
+                        modifyHeaders().remove("Content-Type")
+                    ),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (UNAUTHORIZED)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+    }
+
+    @Test
+    @DisplayName("토큰 없음 — 조회 시 404")
+    void 토큰_없음_조회_404() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID programId = UUID.randomUUID();
+
+        when(queueTokenService.getToken(any())).thenThrow(new TokenNotFoundException());
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId).thenReturn(userId);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
+                    .header("X-User-Id", userId.toString()))
+                .andExpect(status().isNotFound())
+                .andDo(document("queue-token-get-not-found",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+    }
+
+    @Test
+    @DisplayName("토큰 없음 — 취소 시 404")
+    void 토큰_없음_취소_404() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID programId = UUID.randomUUID();
+
+        doThrow(new TokenNotFoundException()).when(queueTokenService).cancelToken(any());
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId).thenReturn(userId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
+                    .header("X-User-Id", userId.toString()))
+                .andExpect(status().isNotFound())
+                .andDo(document("queue-token-cancel-not-found",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+    }
+
+    @Test
+    @DisplayName("WAITING 이 아닌 상태 취소 시도 — 400")
+    void 취소_불가_상태_400() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID programId = UUID.randomUUID();
+
+        doThrow(new InvalidTokenStateException()).when(queueTokenService).cancelToken(any());
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId).thenReturn(userId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
+                    .header("X-User-Id", userId.toString()))
+                .andExpect(status().isBadRequest())
+                .andDo(document("queue-token-cancel-invalid-state",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (INVALID_TOKEN_STATE)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+    }
+}

--- a/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
+++ b/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
@@ -7,6 +7,7 @@ import com.firstticket.common.web.AuthContext;
 import com.firstticket.queueservice.application.QueueTokenService;
 import com.firstticket.queueservice.application.dto.QueueTokenResult;
 import com.firstticket.queueservice.domain.QueueToken;
+import com.firstticket.queueservice.domain.exception.DuplicateTokenException;
 import com.firstticket.queueservice.domain.exception.InvalidTokenStateException;
 import com.firstticket.queueservice.domain.exception.TokenNotFoundException;
 import com.firstticket.queueservice.domain.vo.ProgramId;
@@ -45,6 +46,20 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * 대기열 API 통합 테스트.
+ *
+ * <p>WebMvcTest 슬라이스로 Controller 만 로드하고 Service 는 mock 한다.
+ * 테스트 통과 시 REST Docs snippet 이 자동 생성되며,
+ * AsciiDoc 빌드를 거쳐 build/docs/asciidoc/index.html 로 문서화된다.
+ *
+ * <p>주요 검증:
+ * <ul>
+ *   <li>HTTP 메서드별 정상 동작 (POST 201, GET 200, DELETE 204)</li>
+ *   <li>인증 헤더 (X-User-Id) 누락 시 401</li>
+ *   <li>도메인 예외 → HTTP status 매핑 (404, 400, 409)</li>
+ * </ul>
+ */
 @WebMvcTest(QueueTokenController.class)
 @AutoConfigureRestDocs
 @ActiveProfiles("test")
@@ -197,6 +212,37 @@ class QueueTokenControllerTest {
                     responseFields(
                         fieldWithPath("success").description("요청 성공 여부 (false)"),
                         fieldWithPath("code").description("에러 코드 (UNAUTHORIZED)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
+        }
+    }
+
+    @Test
+    @DisplayName("동시 진입 시 race — 409 Conflict")
+    void 중복_진입_409() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID programId = UUID.randomUUID();
+
+        when(queueTokenService.issueToken(any())).thenThrow(new DuplicateTokenException());
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId).thenReturn(userId);
+
+            mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId)
+                    .header("X-User-Id", userId.toString()))
+                .andExpect(status().isConflict())
+                .andDo(document("queue-token-duplicate",
+                    preprocessRequest(
+                        prettyPrint(),
+                        modifyHeaders().remove("Content-Type")
+                    ),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (DUPLICATE_TOKEN)"),
                         fieldWithPath("message").description("에러 메시지"),
                         fieldWithPath("timestamp").description("응답 시각")
                     )


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

#### 성공 케이스
- 대기열 진입 (`POST /api/v1/queues/programs/{programId}`)
- 대기 정보 조회 (`GET /api/v1/queues/programs/{programId}`)
- 대기 취소 (`DELETE /api/v1/queues/programs/{programId}`)

#### 에러 케이스
- X-User-Id 헤더 없음 → 401 Unauthorized
- 토큰 없음 (조회 시) → 404 Not Found
- 토큰 없음 (취소 시) → 404 Not Found
- WAITING 이 아닌 상태 취소 → 400 Bad Request

### REST Docs 생성

테스트 통과 시 자동으로 AsciiDoc snippet 생성 → HTML 문서 빌드.

- snippet: `build/generated-snippets/`
- HTML: `build/docs/asciidoc/index.html`
- AsciiDoc 소스: `src/docs/asciidoc/index.adoc`


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
close #6 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)

### 미래 호환 경고 (무시)

- Mockito self-attaching (JDK 미래 변경)
- Gradle 9.0 deprecation


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 큐 토큰 API 문서 추가 및 개선 — 발급·조회·취소 엔드포인트, 인증 요구사항, 표준 응답 포맷 및 에러 시나리오 문서화
* **테스트**
  * 컨트롤러 동작과 오류 매핑을 검증하는 웹계층 테스트 추가 (발급·조회·취소 및 관련 오류 케이스)
* **잡무(Chores)**
  * 빌드 스크립트에 정적 문서 생성/포장 단계 추가 및 빌드 산출물 경로 관리 업데이트
  * .gitignore에 문서 산출물 경로와 예시 환경파일 예외 규칙 복원 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->