### PR TITLE
[feat][queue-service] 대기열 입장 승인 스케줄러 + JWT 토큰 발급

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,6 @@ gradle-app.setting
 .env
 .env.*
 !.env.example
+
+# REST Docs 빌드 결과
+src/main/resources/static/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,11 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 dependencyManagement {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -60,6 +60,12 @@ include::{snippets}/queue-token-duplicate/response-fields.adoc[]
 
 operation::queue-token-get[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
+=== ADMITTED 상태 응답
+
+큐에서 빠진 후 (입장 가능) 응답.
+
+operation::queue-token-get-admitted[snippets='http-response,response-fields']
+
 === 에러 응답
 
 ==== 토큰 없음 (404)

--- a/src/main/java/com/firstticket/queueservice/QueueServiceApplication.java
+++ b/src/main/java/com/firstticket/queueservice/QueueServiceApplication.java
@@ -3,9 +3,11 @@ package com.firstticket.queueservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class QueueServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/firstticket/queueservice/application/dto/QueueTokenResult.java
+++ b/src/main/java/com/firstticket/queueservice/application/dto/QueueTokenResult.java
@@ -9,13 +9,16 @@ public record QueueTokenResult(
     QueueTokenId tokenId,
     TokenStatus status,
     IssuedAt issuedAt,
-    Long position
+    Long position,
+    String entryToken
 ) {
     public static QueueTokenResult of(QueueToken token, Long position) {
         return new QueueTokenResult(
             token.getId(),
             token.getStatus(),
             token.getIssuedAt(),
-            position);
+            position,
+            token.getEntryToken()
+        );
     }
 }

--- a/src/main/java/com/firstticket/queueservice/config/JwtProperties.java
+++ b/src/main/java/com/firstticket/queueservice/config/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.firstticket.queueservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * JWT 입장 토큰 설정.
+ *
+ * <p>도메인 정책 (TTL) 과 인프라 정책 (비밀키) 모두 포함.
+ */
+@ConfigurationProperties(prefix = "queue.jwt")
+public record JwtProperties(
+    String secret,
+    Duration entryTokenTtl
+) {
+}

--- a/src/main/java/com/firstticket/queueservice/config/JwtProperties.java
+++ b/src/main/java/com/firstticket/queueservice/config/JwtProperties.java
@@ -14,4 +14,12 @@ public record JwtProperties(
     String secret,
     Duration entryTokenTtl
 ) {
+    public JwtProperties {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalArgumentException("queue.jwt.secret must not be blank");
+        }
+        if (entryTokenTtl == null || entryTokenTtl.isZero() || entryTokenTtl.isNegative()) {
+            throw new IllegalArgumentException("queue.jwt.entry-token-ttl must be positive");
+        }
+    }
 }

--- a/src/main/java/com/firstticket/queueservice/domain/QueueToken.java
+++ b/src/main/java/com/firstticket/queueservice/domain/QueueToken.java
@@ -32,6 +32,7 @@ public class QueueToken {
     private final ProgramId programId;
     private final IssuedAt issuedAt;
     private TokenStatus status;
+    private String entryToken;
 
     /**
      * 새로운 대기 토큰을 발급한다.
@@ -44,7 +45,9 @@ public class QueueToken {
             userId,
             programId,
             IssuedAt.now(),
-            TokenStatus.WAITING);
+            TokenStatus.WAITING,
+            null    // entryToken: 발급 시점엔 없음, admit 시 부여
+        );
     }
 
     /**
@@ -55,22 +58,24 @@ public class QueueToken {
         UserId userId,
         ProgramId programId,
         IssuedAt issuedAt,
-        TokenStatus status
+        TokenStatus status,
+        String entryToken
     ) {
         Objects.requireNonNull(id, "QueueTokenId는 필수입니다");
         Objects.requireNonNull(userId, "UserId는 필수입니다");
         Objects.requireNonNull(programId, "ProgramId는 필수입니다");
         Objects.requireNonNull(issuedAt, "IssuedAt은 필수입니다");
         Objects.requireNonNull(status, "TokenStatus는 필수입니다");
-        return new QueueToken(id, userId, programId, issuedAt, status);
+        return new QueueToken(id, userId, programId, issuedAt, status, entryToken);
     }
 
     /**
      * 입장을 승인한다 (WAITING -> ADMITTED)
      */
-    public void admit() {
+    public void admit(String entryToken) {
         ensureWaiting();
         this.status = TokenStatus.ADMITTED;
+        this.entryToken = entryToken;
     }
 
     /**

--- a/src/main/java/com/firstticket/queueservice/domain/QueueTokenRepository.java
+++ b/src/main/java/com/firstticket/queueservice/domain/QueueTokenRepository.java
@@ -50,4 +50,13 @@ public interface QueueTokenRepository {
      */
     List<QueueToken> findAdmissionCandidates(ProgramId programId, int batchSize);
 
+    /**
+     * 입장 승인된 토큰의 상태를 업데이트한다.
+     */
+    void admit(QueueToken token);
+
+    /**
+     * 현재 큐가 존재하는 모든 프로그램 ID 를 조회한다.
+     */
+    List<ProgramId> findActiveProgramIds();
 }

--- a/src/main/java/com/firstticket/queueservice/infrastructure/jwt/EntryTokenIssuer.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/jwt/EntryTokenIssuer.java
@@ -1,0 +1,56 @@
+package com.firstticket.queueservice.infrastructure.jwt;
+
+import com.firstticket.queueservice.config.JwtProperties;
+import com.firstticket.queueservice.domain.QueueToken;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * 입장 토큰 (JWT) 발급기.
+ *
+ * <p>대기열에서 admit 된 사용자에게 발급되는 JWT.
+ * 예매 서비스가 stateless 하게 검증한다 (queue-service 별도 호출 X).
+ */
+@Component
+public class EntryTokenIssuer {
+
+    private static final String ISSUER = "queue-service";
+    private static final String CLAIM_PROGRAM_ID = "programId";
+
+    private final SecretKey secretKey;
+    private final Duration ttl;
+
+    public EntryTokenIssuer(JwtProperties properties) {
+        this.secretKey = Keys.hmacShaKeyFor(properties.secret().getBytes(StandardCharsets.UTF_8));
+        this.ttl = properties.entryTokenTtl();
+    }
+
+    /**
+     * 입장 토큰을 발급한다.
+     *
+     * @param token admit 된 대기 토큰
+     * @return JWT 형식의 입장 토큰
+     */
+    public String issue(QueueToken token) {
+        Instant now = Instant.now();
+        Instant expiration = now.plus(ttl);
+
+        return Jwts.builder()
+            .id(UUID.randomUUID().toString())
+            .issuer(ISSUER)
+            .subject(token.getUserId().asString())
+            .claim(CLAIM_PROGRAM_ID, token.getProgramId().asString())
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiration))
+            .signWith(secretKey)
+            .compact();
+    }
+}

--- a/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepository.java
@@ -11,17 +11,12 @@ import com.firstticket.queueservice.domain.vo.QueueTokenId;
 import com.firstticket.queueservice.domain.vo.UserId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.HashOperations;
-import org.springframework.data.redis.core.RedisOperations;
-import org.springframework.data.redis.core.SessionCallback;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.*;
 import org.springframework.stereotype.Repository;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 /**
  * 대기 토큰의 Redis 기반 영속성 구현체.
@@ -52,6 +47,7 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
     private static final String FIELD_PROGRAM_ID = "programId";
     private static final String FIELD_ISSUED_AT = "issuedAt";
     private static final String FIELD_STATUS = "status";
+    private static final String FIELD_ENTRY_TOKEN = "entryToken";
 
     private final StringRedisTemplate redisTemplate;
     private final QueueProperties properties;
@@ -161,8 +157,9 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
         ProgramId programId = ProgramId.fromString(entries.get(FIELD_PROGRAM_ID));
         IssuedAt issuedAt = IssuedAt.fromEpochMilli(Long.parseLong(entries.get(FIELD_ISSUED_AT)));
         TokenStatus status = TokenStatus.valueOf(entries.get(FIELD_STATUS));
+        String entryToken = entries.get(FIELD_ENTRY_TOKEN);     // null 가능 (WAITING 상태)
 
-        return QueueToken.restore(id, userId, programId, issuedAt, status);
+        return QueueToken.restore(id, userId, programId, issuedAt, status, entryToken);
     }
 
     /**
@@ -301,6 +298,94 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
             .filter(Optional::isPresent)
             // Optional<QueueToken> → QueueToken
             .map(Optional::get)
+            .toList();
+    }
+
+    /**
+     * Redis 기반 admit 구현.
+     *
+     * <p>2가지 작업을 트랜잭션으로 처리한다:
+     * <ol>
+     *   <li>Sorted Set 에서 토큰 멤버 제거 (큐에서 빠짐 → position 조회 X)</li>
+     *   <li>Hash 의 status / entryToken 업데이트</li>
+     * </ol>
+     *
+     * <p>역인덱스는 유지 — 사용자가 GET 으로 자기 토큰 조회 가능 (status: ADMITTED 응답).
+     */
+    public void admit(QueueToken token) {
+        String programKey = programKey(token.getProgramId());
+        String tokenKey = tokenKey(token.getId());
+        String tokenIdStr = token.getId().asString();
+
+        Map<String, String> updates = Map.of(
+            FIELD_STATUS, token.getStatus().name(),
+            FIELD_ENTRY_TOKEN, token.getEntryToken()
+        );
+
+        redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @SuppressWarnings({"unchecked"})
+            @Override
+            public List<Object> execute(RedisOperations operations) {
+                operations.multi();
+
+                // 1. Sorted Set 에서 멤버 제거 (큐에서 빠짐)
+                operations.opsForZSet().remove(programKey, tokenIdStr);
+
+                // 2. Hash 의 status / entryToken 업데이트
+                operations.opsForHash().putAll(tokenKey, updates);
+
+                return operations.exec();
+            }
+        });
+    }
+
+    /**
+     * Redis 기반 findActiveProgramIds 구현.
+     *
+     * <p>{@code queue:program:*} 패턴으로 SCAN 하여 활성 프로그램 ID 목록을 반환한다.
+     *
+     * <p>SCAN 사용 이유: KEYS 명령은 production 에서 블로킹 발생 위험. SCAN 은 점진적.
+     *
+     * <h3>Future Work</h3>
+     * 본 메서드는 MVP 의 가정 (큐 존재 = 활성 프로그램) 을 따른다.
+     * <p>program-service 와 Kafka 이벤트 통합 후엔:
+     * <ul>
+     *   <li>{@code program.opened} 이벤트 → Redis Set 의 활성 프로그램 추가</li>
+     *   <li>{@code program.closed} 이벤트 → Set 에서 제거</li>
+     *   <li>본 메서드는 Redis Set 직접 조회 (SCAN 불필요)</li>
+     * </ul>
+     */
+    public List<ProgramId> findActiveProgramIds() {
+        String pattern = QUEUE_KEY_PREFIX + PROGRAM_KEY_PREFIX + "*";
+
+        // 1. SCAN 으로 모든 큐 키 수집
+        Set<String> keys = redisTemplate.execute((RedisCallback<Set<String>>) connection -> {
+            Set<String> result = new HashSet<>();
+            ScanOptions options = ScanOptions.scanOptions()
+                .match(pattern)     // queue:program:* 매칭
+                .count(100)         // 한 번에 100 개씩 점진적 조회
+                .build();
+
+            // try-with-resources 로 cursor 자동 정리
+            try (Cursor<byte[]> cursor = connection.scan(options)) {
+                while (cursor.hasNext()) {
+                    // Redis 는 byte[] 반환 → UTF-8 문자열로 변환
+                    result.add(new String(cursor.next(), StandardCharsets.UTF_8));
+                }
+            }
+            return result;
+        });
+
+        if (keys == null || keys.isEmpty()) {
+            return List.of();
+        }
+
+        // 2. 키에서 UUID 추출하여 ProgramId 로 변환
+        // 예: "queue:program:abc-123" → "abc-123" → ProgramId.of("abc-123")
+        String prefix = QUEUE_KEY_PREFIX + PROGRAM_KEY_PREFIX;
+        return keys.stream()
+            .map(key -> key.substring(prefix.length()))
+            .map(ProgramId::fromString)
             .toList();
     }
 

--- a/src/main/java/com/firstticket/queueservice/infrastructure/scheduler/AdmissionScheduler.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/scheduler/AdmissionScheduler.java
@@ -4,7 +4,6 @@ import com.firstticket.queueservice.config.QueueProperties;
 import com.firstticket.queueservice.domain.QueueToken;
 import com.firstticket.queueservice.domain.QueueTokenRepository;
 import com.firstticket.queueservice.domain.vo.ProgramId;
-import com.firstticket.queueservice.domain.vo.QueueTokenId;
 import com.firstticket.queueservice.infrastructure.jwt.EntryTokenIssuer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +56,13 @@ public class AdmissionScheduler {
         log.debug("[AdmissionScheduler] 활성 프로그램 {} 개 발견", activePrograms.size());
 
         for (ProgramId programId : activePrograms) {
-            admitProgram(programId);
+            try {
+                admitProgram(programId);
+            } catch (Exception e) {
+                // 한 프로그램의 실패가 다른 프로그램 처리에 영향을 주지 않도록 격리
+                log.error("[AdmissionScheduler] program 단위 처리 실패 - programId={}",
+                    programId.asString(), e);
+            }
         }
     }
 
@@ -77,11 +82,16 @@ public class AdmissionScheduler {
         int successCount = 0;
         for (QueueToken queueToken : candidates) {
             try {
+                // 1. JWT 입장 토큰 발급
                 String entryToken = entryTokenIssuer.issue(queueToken);
+                // 2. 도메인 상태 전이 (WAITING -> ADMITTED) + entryToken 부여
                 queueToken.admit(entryToken);
+                // 3. Redis 영속성 (Sorted Set 제거 + Hash status/entryToken 갱신)
                 queueTokenRepository.admit(queueToken);
                 successCount++;
             } catch (Exception e) {
+                // 한 토큰의 실패가 같은 batch 의 다른 토큰을 막지 않도록 격리
+                // 실패한 토큰은 Sorted Set 에 남아 다음 cycle 에서 재시도
                 log.error("[AdmissionScheduler] admit 실패 - tokenId={}, programId={}",
                     queueToken.getId().asString(), programId.asString(), e);
             }

--- a/src/main/java/com/firstticket/queueservice/infrastructure/scheduler/AdmissionScheduler.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/scheduler/AdmissionScheduler.java
@@ -1,0 +1,93 @@
+package com.firstticket.queueservice.infrastructure.scheduler;
+
+import com.firstticket.queueservice.config.QueueProperties;
+import com.firstticket.queueservice.domain.QueueToken;
+import com.firstticket.queueservice.domain.QueueTokenRepository;
+import com.firstticket.queueservice.domain.vo.ProgramId;
+import com.firstticket.queueservice.domain.vo.QueueTokenId;
+import com.firstticket.queueservice.infrastructure.jwt.EntryTokenIssuer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 대기열 입장 승인 스케줄러.
+ *
+ * <p>주기적으로 활성 프로그램의 큐 앞에서 batchSize 명을 admit 한다.
+ * admit 시점에 JWT 입장 토큰을 발급하고, QueueToken 의 상태를 ADMITTED 로 전이시킨다.
+ *
+ * <p>흐름:
+ * <ol>
+ *   <li>Redis SCAN 으로 활성 프로그램 (큐가 존재하는 프로그램) 발견</li>
+ *   <li>각 프로그램의 큐 앞에서 batchSize 명 조회 (Sorted Set ZRANGE)</li>
+ *   <li>각 토큰에 대해 JWT 입장 토큰 발급 + 도메인 상태 전이 + Redis 영속성</li>
+ * </ol>
+ *
+ * <p>MVP 단계 한계:
+ * <ul>
+ *   <li>단일 인스턴스 가정 — 여러 인스턴스에서 동시 실행 시 race 가능 (v0.2.0 별도 이슈)</li>
+ *   <li>활성 프로그램 발견을 Redis SCAN 에 의존 — program-service 통합 후 변경</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdmissionScheduler {
+
+    private final QueueTokenRepository queueTokenRepository;
+    private final EntryTokenIssuer entryTokenIssuer;
+    private QueueProperties queueProperties;
+
+    /**
+     * 매 5 초마다 활성 프로그램의 큐 앞 batchSize 명을 admit.
+     *
+     * <p>fixedRate 5000ms = 이전 실행이 끝나든 안 끝나든 5 초마다 시작.
+     */
+    @Scheduled(fixedRate = 5000)
+    public void admit() {
+        List<ProgramId> activePrograms = queueTokenRepository.findActiveProgramIds();
+
+        if (activePrograms.isEmpty()) {
+            return;
+        }
+
+        log.debug("[AdmissionScheduler] 활성 프로그램 {} 개 발견", activePrograms.size());
+
+        for (ProgramId programId : activePrograms) {
+            admitProgram(programId);
+        }
+    }
+
+    /**
+     * 특정 프로그램의 큐 앞 batchSize 명을 admit.
+     *
+     * <p>한 토큰의 admit 실패가 다른 토큰 처리에 영향을 주지 않도록 개별 try-catch 처리.
+     */
+    private void admitProgram(ProgramId programId) {
+        int batchSize = queueProperties.admissionBatchSize();
+        List<QueueToken> candidates = queueTokenRepository.findAdmissionCandidates(programId, batchSize);
+
+        if (candidates.isEmpty()) {
+            return;
+        }
+
+        int successCount = 0;
+        for (QueueToken queueToken : candidates) {
+            try {
+                queueToken.admit(entryTokenIssuer.issue(queueToken));
+                successCount++;
+            } catch (Exception e) {
+                log.error("[AdmissionScheduler] admit 실패 - tokenId={}, programId={}",
+                    queueToken.getId().asString(), programId.asString(), e);
+            }
+        }
+
+        if (successCount < candidates.size()) {
+            log.warn("[AdmissionScheduler] 부분 실패 - programId={}, success={}/{}",
+                programId.asString(), successCount, candidates.size());
+        }
+    }
+}

--- a/src/main/java/com/firstticket/queueservice/infrastructure/scheduler/AdmissionScheduler.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/scheduler/AdmissionScheduler.java
@@ -39,7 +39,7 @@ public class AdmissionScheduler {
 
     private final QueueTokenRepository queueTokenRepository;
     private final EntryTokenIssuer entryTokenIssuer;
-    private QueueProperties queueProperties;
+    private final QueueProperties queueProperties;
 
     /**
      * 매 5 초마다 활성 프로그램의 큐 앞 batchSize 명을 admit.
@@ -77,7 +77,9 @@ public class AdmissionScheduler {
         int successCount = 0;
         for (QueueToken queueToken : candidates) {
             try {
-                queueToken.admit(entryTokenIssuer.issue(queueToken));
+                String entryToken = entryTokenIssuer.issue(queueToken);
+                queueToken.admit(entryToken);
+                queueTokenRepository.admit(queueToken);
                 successCount++;
             } catch (Exception e) {
                 log.error("[AdmissionScheduler] admit 실패 - tokenId={}, programId={}",

--- a/src/main/java/com/firstticket/queueservice/presentation/dto/QueueTokenResponse.java
+++ b/src/main/java/com/firstticket/queueservice/presentation/dto/QueueTokenResponse.java
@@ -1,21 +1,25 @@
 package com.firstticket.queueservice.presentation.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.firstticket.queueservice.application.dto.QueueTokenResult;
 
 import java.time.LocalDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record QueueTokenResponse(
     String tokenId,
     String status,
     LocalDateTime issuedAt,
-    Long position
+    Long position,
+    String entryToken
 ) {
     public static QueueTokenResponse from(QueueTokenResult result) {
         return new QueueTokenResponse(
             result.tokenId().asString(),
             result.status().name(),
             result.issuedAt().value(),
-            result.position()
+            result.position(),
+            result.entryToken()
         );
     }
 }

--- a/src/test/java/com/firstticket/queueservice/domain/QueueTokenTest.java
+++ b/src/test/java/com/firstticket/queueservice/domain/QueueTokenTest.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class QueueTokenTest {
 
+    private static final String DUMMY_ENTRY_TOKEN = "dummy-entry-token";
+
     private final UserId userId = UserId.of(UUID.randomUUID());
     private final ProgramId programId = ProgramId.of(UUID.randomUUID());
 
@@ -28,6 +30,14 @@ class QueueTokenTest {
             QueueToken token = QueueToken.issue(userId, programId);
 
             assertThat(token.getStatus()).isEqualTo(TokenStatus.WAITING);
+        }
+
+        @Test
+        @DisplayName("발급 시 entryToken은 null 이다")
+        void 발급_시_entryToken_null() {
+            QueueToken token = QueueToken.issue(userId, programId);
+
+            assertThat(token.getEntryToken()).isNull();
         }
 
         @Test
@@ -51,14 +61,14 @@ class QueueTokenTest {
         @DisplayName("UserId가 null이면 예외가 발생한다")
         void userId_null_예외() {
             assertThatThrownBy(() -> QueueToken.issue(null, programId))
-                .isInstanceOf(NullPointerException.class);
+                    .isInstanceOf(NullPointerException.class);
         }
 
         @Test
         @DisplayName("ProgramId가 null이면 예외가 발생한다")
         void programId_null_예외() {
             assertThatThrownBy(() -> QueueToken.issue(userId, null))
-                .isInstanceOf(NullPointerException.class);
+                    .isInstanceOf(NullPointerException.class);
         }
     }
 
@@ -71,21 +81,31 @@ class QueueTokenTest {
         void waiting에서_admit_성공() {
             QueueToken token = QueueToken.issue(userId, programId);
 
-            token.admit();
+            token.admit(DUMMY_ENTRY_TOKEN);
 
             assertThat(token.getStatus()).isEqualTo(TokenStatus.ADMITTED);
+        }
+
+        @Test
+        @DisplayName("admit 시 entryToken이 저장된다")
+        void admit_시_entryToken_저장() {
+            QueueToken token = QueueToken.issue(userId, programId);
+
+            token.admit(DUMMY_ENTRY_TOKEN);
+
+            assertThat(token.getEntryToken()).isEqualTo(DUMMY_ENTRY_TOKEN);
         }
 
         @Test
         @DisplayName("이미 ADMITTED 상태에서 admit 시 예외가 발생한다")
         void admitted에서_admit_시_예외() {
             QueueToken token = QueueToken.issue(userId, programId);
-            token.admit();
+            token.admit(DUMMY_ENTRY_TOKEN);
 
-            assertThatThrownBy(token::admit)
-                .isInstanceOf(InvalidTokenStateException.class)
-                .extracting("errorCode")
-                .isEqualTo(QueueErrorCode.INVALID_TOKEN_STATE);
+            assertThatThrownBy(() -> token.admit(DUMMY_ENTRY_TOKEN))
+                    .isInstanceOf(InvalidTokenStateException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(QueueErrorCode.INVALID_TOKEN_STATE);
         }
 
         @Test
@@ -94,8 +114,8 @@ class QueueTokenTest {
             QueueToken token = QueueToken.issue(userId, programId);
             token.cancel();
 
-            assertThatThrownBy(token::admit)
-                .isInstanceOf(InvalidTokenStateException.class);
+            assertThatThrownBy(() -> token.admit(DUMMY_ENTRY_TOKEN))
+                    .isInstanceOf(InvalidTokenStateException.class);
         }
 
         @Test
@@ -104,8 +124,8 @@ class QueueTokenTest {
             QueueToken token = QueueToken.issue(userId, programId);
             token.expire();
 
-            assertThatThrownBy(token::admit)
-                .isInstanceOf(InvalidTokenStateException.class);
+            assertThatThrownBy(() -> token.admit(DUMMY_ENTRY_TOKEN))
+                    .isInstanceOf(InvalidTokenStateException.class);
         }
     }
 
@@ -127,10 +147,10 @@ class QueueTokenTest {
         @DisplayName("ADMITTED 상태에서 cancel 시 예외가 발생한다")
         void admitted에서_cancel_시_예외() {
             QueueToken token = QueueToken.issue(userId, programId);
-            token.admit();
+            token.admit(DUMMY_ENTRY_TOKEN);
 
             assertThatThrownBy(token::cancel)
-                .isInstanceOf(InvalidTokenStateException.class);
+                    .isInstanceOf(InvalidTokenStateException.class);
         }
     }
 
@@ -155,7 +175,7 @@ class QueueTokenTest {
             token.cancel();
 
             assertThatThrownBy(token::expire)
-                .isInstanceOf(InvalidTokenStateException.class);
+                    .isInstanceOf(InvalidTokenStateException.class);
         }
     }
 
@@ -164,17 +184,18 @@ class QueueTokenTest {
     class Restore {
 
         @Test
-        @DisplayName("저장된 상태 그대로 복원된다")
-        void 저장된_상태_그대로_복원() {
+        @DisplayName("ADMITTED 토큰을 entryToken과 함께 복원한다")
+        void ADMITTED_토큰_복원() {
             QueueToken issued = QueueToken.issue(userId, programId);
-            issued.admit();
+            issued.admit(DUMMY_ENTRY_TOKEN);
 
             QueueToken restored = QueueToken.restore(
-                issued.getId(),
-                issued.getUserId(),
-                issued.getProgramId(),
-                issued.getIssuedAt(),
-                issued.getStatus()
+                    issued.getId(),
+                    issued.getUserId(),
+                    issued.getProgramId(),
+                    issued.getIssuedAt(),
+                    issued.getStatus(),
+                    issued.getEntryToken()
             );
 
             assertThat(restored.getId()).isEqualTo(issued.getId());
@@ -182,6 +203,25 @@ class QueueTokenTest {
             assertThat(restored.getProgramId()).isEqualTo(issued.getProgramId());
             assertThat(restored.getIssuedAt()).isEqualTo(issued.getIssuedAt());
             assertThat(restored.getStatus()).isEqualTo(TokenStatus.ADMITTED);
+            assertThat(restored.getEntryToken()).isEqualTo(DUMMY_ENTRY_TOKEN);
+        }
+
+        @Test
+        @DisplayName("WAITING 토큰은 entryToken null 로 복원된다")
+        void WAITING_토큰_복원() {
+            QueueToken issued = QueueToken.issue(userId, programId);
+
+            QueueToken restored = QueueToken.restore(
+                    issued.getId(),
+                    issued.getUserId(),
+                    issued.getProgramId(),
+                    issued.getIssuedAt(),
+                    issued.getStatus(),
+                    null
+            );
+
+            assertThat(restored.getStatus()).isEqualTo(TokenStatus.WAITING);
+            assertThat(restored.getEntryToken()).isNull();
         }
     }
 }

--- a/src/test/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepositoryTest.java
+++ b/src/test/java/com/firstticket/queueservice/infrastructure/redis/RedisQueueTokenRepositoryTest.java
@@ -336,6 +336,131 @@ class RedisQueueTokenRepositoryTest {
         }
     }
 
+    @Nested
+    @DisplayName("admit")
+    class Admit {
+
+        @Test
+        @DisplayName("admit 후 Sorted Set 에서 제거되어 position 조회되지 않는다")
+        void admit_후_position_없음() {
+            // given
+            UserId userId = UserId.of(UUID.randomUUID());
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+            QueueToken token = QueueToken.issue(userId, programId);
+            repository.enqueue(token);
+
+            // when
+            token.admit("dummy-jwt-token");
+            repository.admit(token);
+
+            // then
+            Optional<Long> position = repository.findPosition(userId, programId);
+            assertThat(position).isEmpty();
+        }
+
+        @Test
+        @DisplayName("admit 후 status 와 entryToken 이 영속된다")
+        void admit_후_status_entryToken_저장() {
+            // given
+            UserId userId = UserId.of(UUID.randomUUID());
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+            QueueToken token = QueueToken.issue(userId, programId);
+            repository.enqueue(token);
+
+            // when
+            String entryToken = "dummy-jwt-token";
+            token.admit(entryToken);
+            repository.admit(token);
+
+            // then
+            Optional<QueueToken> found = repository.findById(token.getId());
+            assertThat(found).isPresent();
+            assertThat(found.get().getStatus()).isEqualTo(TokenStatus.ADMITTED);
+            assertThat(found.get().getEntryToken()).isEqualTo(entryToken);
+        }
+
+        @Test
+        @DisplayName("admit 후에도 사용자가 자기 토큰 조회 가능 (역인덱스 유지)")
+        void admit_후_사용자_조회_가능() {
+            // given
+            UserId userId = UserId.of(UUID.randomUUID());
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+            QueueToken token = QueueToken.issue(userId, programId);
+            repository.enqueue(token);
+
+            // when
+            token.admit("dummy-jwt-token");
+            repository.admit(token);
+
+            // then
+            Optional<QueueToken> found = repository.findByUserIdAndProgramId(userId, programId);
+            assertThat(found).isPresent();
+            assertThat(found.get().getStatus()).isEqualTo(TokenStatus.ADMITTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("findActiveProgramIds")
+    class FindActiveProgramIds {
+
+        @Test
+        @DisplayName("큐가 없으면 빈 리스트 반환")
+        void 큐_없음_빈_리스트() {
+            List<ProgramId> result = repository.findActiveProgramIds();
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("한 프로그램에 토큰이 있으면 그 프로그램 ID 1 개 반환")
+        void 한_프로그램_1_개() {
+            // given
+            UserId userId = UserId.of(UUID.randomUUID());
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+            repository.enqueue(QueueToken.issue(userId, programId));
+
+            // when
+            List<ProgramId> result = repository.findActiveProgramIds();
+
+            // then
+            assertThat(result).containsExactly(programId);
+        }
+
+        @Test
+        @DisplayName("여러 프로그램에 토큰이 있으면 모든 프로그램 ID 반환")
+        void 여러_프로그램_모두() {
+            // given
+            ProgramId program1 = ProgramId.of(UUID.randomUUID());
+            ProgramId program2 = ProgramId.of(UUID.randomUUID());
+            ProgramId program3 = ProgramId.of(UUID.randomUUID());
+            repository.enqueue(QueueToken.issue(UserId.of(UUID.randomUUID()), program1));
+            repository.enqueue(QueueToken.issue(UserId.of(UUID.randomUUID()), program2));
+            repository.enqueue(QueueToken.issue(UserId.of(UUID.randomUUID()), program3));
+
+            // when
+            List<ProgramId> result = repository.findActiveProgramIds();
+
+            // then
+            assertThat(result).containsExactlyInAnyOrder(program1, program2, program3);
+        }
+
+        @Test
+        @DisplayName("같은 프로그램에 여러 토큰이 있어도 프로그램 ID 1 개만 반환")
+        void 같은_프로그램_중복_X() {
+            // given
+            ProgramId programId = ProgramId.of(UUID.randomUUID());
+            repository.enqueue(QueueToken.issue(UserId.of(UUID.randomUUID()), programId));
+            repository.enqueue(QueueToken.issue(UserId.of(UUID.randomUUID()), programId));
+            repository.enqueue(QueueToken.issue(UserId.of(UUID.randomUUID()), programId));
+
+            // when
+            List<ProgramId> result = repository.findActiveProgramIds();
+
+            // then
+            assertThat(result).containsExactly(programId);
+        }
+    }
+
     private QueueToken newToken() {
         return QueueToken.issue(
             UserId.of(UUID.randomUUID()),

--- a/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
+++ b/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
@@ -336,4 +336,47 @@ class QueueTokenControllerTest {
                 ));
         }
     }
+
+    @Test
+    @DisplayName("ADMITTED 상태 토큰 조회 시 entryToken 응답에 포함")
+    void ADMITTED_조회_entryToken_포함() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID programId = UUID.randomUUID();
+        QueueToken token = QueueToken.issue(UserId.of(userId), ProgramId.of(programId));
+        String entryToken = "eyJhbGc.dummy.jwt";
+        token.admit(entryToken);
+        QueueTokenResult result = QueueTokenResult.of(token, null);   // position null
+
+        when(queueTokenService.getToken(any())).thenReturn(result);
+
+        try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
+            mocked.when(AuthContext::getUserId).thenReturn(userId);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
+                    .header("X-User-Id", userId.toString()))
+                .andExpect(status().isOk())
+                .andDo(document("queue-token-get-admitted",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("programId").description("프로그램 ID")
+                    ),
+                    requestHeaders(
+                        headerWithName("X-User-Id").description("Gateway 가 주입한 사용자 ID")
+                    ),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부"),
+                        fieldWithPath("code").description("응답 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각"),
+                        fieldWithPath("data.tokenId").description("토큰 ID"),
+                        fieldWithPath("data.status").description("토큰 상태 (ADMITTED)"),
+                        fieldWithPath("data.issuedAt").description("발급 시각"),
+                        fieldWithPath("data.entryToken").description("입장 토큰 (JWT) — ADMITTED 상태일 때만 포함")
+                    )
+                ));
+        }
+    }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,3 +13,8 @@ queue:
   token:
     waiting-ttl: PT30M
     admission-batch-size: 100
+
+  jwt:
+    secret: "test-secret-key-for-jwt-issuance-must-be-at-least-256-bit"
+    entry-token-ttl: PT3M
+


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

대기열 사용자가 큐에서 빠질 때 (admit 시점) JWT 형식의 입장 토큰을 발급하는 기능을 구현했습니다.
 
클라이언트는 GET 폴링 중 status 가 `ADMITTED` 로 바뀌면 응답에 포함된 입장 토큰을 받아 예매 서비스로 이동합니다.
예매 서비스는 stateless 하게 JWT 만 검증하므로 queue-service 별도 호출이 필요 없습니다.

### 흐름
```
1. 사용자 대기열 진입 (POST)
2. 클라이언트 폴링 (GET) — status: WAITING, position 줄어듦
3. 스케줄러: 매 5 초마다 큐 앞 batchSize 명 admit
   - QueueToken 상태 WAITING → ADMITTED
   - JWT 입장 토큰 발급
4. 클라 폴링 (GET) — status: ADMITTED, entryToken 포함
5. 클라가 entryToken 을 헤더로 예매 서비스 호출
6. 예매 서비스가 JWT 검증 (stateless) 후 별도 토큰 발급
```

### 작업 내용
 
#### JWT 발급
- JJWT 0.12.6 의존성 추가
- `JwtProperties` (config/) — `queue.jwt.secret` / `entry-token-ttl` 매핑
- `EntryTokenIssuer` — JWT 발급기
#### 도메인
- `QueueToken` 에 `entryToken` 필드 추가 (ADMITTED 일 때만 값)
- `admit()` 시그니처 변경: `admit(String entryToken)`
- `restore()` 시그니처에 `entryToken` 추가
#### Repository
- `admit(QueueToken)` 메서드 추가 — Sorted Set 제거 + Hash status/entryToken 갱신
- `findActiveProgramIds()` 메서드 추가 — Redis SCAN 으로 활성 프로그램 발견
#### 스케줄러
- `AdmissionScheduler` 신규 — 매 5 초마다 활성 프로그램 발견 후 batchSize 명 admit
- `@EnableScheduling` 활성화
- 한 토큰의 admit 실패가 다른 토큰 처리에 영향을 주지 않도록 개별 try-catch
#### 응답 모델
- `QueueTokenResult` / `QueueTokenResponse` 에 `entryToken` 필드 추가
- `@JsonInclude(NON_NULL)` 적용 — WAITING 상태일 땐 `entryToken` / `position` 자동 제외
#### Config
- `queue-service.yml` 에 JWT 설정 추가 (`secret`, `entry-token-ttl`)
#### 테스트
- `QueueToken` 도메인 테스트 — admit 의 새 시그니처 + entryToken 검증
- `RedisQueueTokenRepository` 통합 테스트 — admit / findActiveProgramIds 동작 검증
- `QueueTokenController` 테스트 — ADMITTED 상태 조회 시 entryToken 응답 검증
### 📌 JWT Payload
 
| 필드명 | 타입 | NULL | 설명 |
|---|---|---|---|
| `jti` | UUID | NOT NULL | 발급된 입장 토큰의 고유 ID |
| `iss` | String | NOT NULL | 발급 서비스 (`queue-service`) |
| `sub` | UUID | NOT NULL | 입장 승인받은 사용자 ID |
| `programId` | UUID | NOT NULL | 공연 ID |
| `iat` | Long (epoch sec) | NOT NULL | 입장 토큰 발급 시각 |
| `exp` | Long (epoch sec) | NOT NULL | 입장 토큰 만료 시각 |


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
close #17 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)

### 1. 단일 인스턴스 가정 (Race Condition)
- 스케줄러가 여러 인스턴스에서 실행되면 같은 토큰 중복 처리 가능
- 해결: 분산 락 또는 Redis Lua Script 통합 (v0.2.0 별도 이슈)
### 2. 활성 프로그램 발견 — Redis SCAN
- 현재: 큐가 존재하는 프로그램 = 활성 프로그램 으로 가정
- 도메인 본질은 program-service 가 예매 시작 시 명시적으로 활성화해야 함
- 해결: program-service 통합 (별도 이슈) — 통신 방식은 팀 토론 진행 중
### 3. 시각 정책 검사 미구현
- 진입 시 / 스케줄러 시 `openAt` / `closeAt` 검사 미구현
- 해결: program-service 통합 작업과 함께


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 대기열의 자동 승인(주기적 처리) 기능 추가
  * 승인 시 발급되는 입장 토큰(Entry Token) 생성 및 토큰에 포함

* **응답/직렬화**
  * 토큰 조회 응답에 입장 토큰(entryToken) 포함 및 null 필드 미포함 처리

* **설정**
  * JWT 발급 설정(비밀키 및 만료시간) 추가 및 검증 강화
  * 빌드에 JWT 라이브러리 지원 추가

* **테스트**
  * 입장 토큰 및 승인 흐름을 포함한 단위·통합 테스트 보강

* **문서**
  * 대기열 토큰 조회 응답의 ADMITTED 상태 명세 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->