### PR TITLE
[docs][queue-service] 문서 정리 + 대기 취소 응답 200 OK 로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ First Ticket 프로젝트의 대기열 서비스.
 
 ---
 
+## 📌 핵심 기능
+
+티켓 예매가 열리면 사용자들이 동시에 몰리면서 예매 시스템이 부담이 간다.
+queue-service 는 사용자를 대기열에 줄 세우고 일정 인원씩만 입장을 승인하여 트래픽을 제어한다.
+
+### 주요 흐름
+
+1. 사용자가 큐 진입 (대기 토큰 발급)
+2. 클라이언트가 폴링으로 자기 순번 조회
+3. 스케줄러가 일정 주기로 큐 앞에서 batchSize 명을 입장 승인
+4. 입장 승인된 사용자에게 JWT 입장 토큰 발급
+5. 사용자는 입장 토큰을 가지고 예매 서비스로 진입
+
+---
+
 ## 🛠 기술 스택
 
 | 항목 | 기술 |
@@ -14,56 +29,36 @@ First Ticket 프로젝트의 대기열 서비스.
 | Spring Cloud | 2025.0.2 |
 | 빌드 도구 | Gradle |
 | 저장소 | Redis |
+| JWT | jjwt 0.12.6 |
 | 서비스 디스커버리 | Eureka |
 | 설정 관리 | Spring Cloud Config |
+| API 문서 | Spring REST Docs (AsciiDoc) |
 
 ---
 
+## 📁 패키지 구조
 
-## 🚀 로컬 실행
+DDD + 헥사고날 아키텍처 기반.
 
-### 사전 조건
-
-다음 인프라가 먼저 실행되어 있어야 한다.
-
-1. **infra 레포의 docker-compose** — Redis, PostgreSQL, Keycloak 등
-2. **config-server** — 설정 관리 서버
-3. **eureka-server** — 서비스 디스커버리
-
-### 실행 순서
-
-```bash
-# 1. infra 기동
-cd ../infra
-docker-compose -f docker/docker-compose.yml --env-file .env up -d
-
-# 2. config-server 기동
-cd ../config-server
-./gradlew bootRun
-
-# 3. eureka-server 기동
-cd ../eureka-server
-./gradlew bootRun
-
-# 4. queue-service 기동
-cd ../queue-service
-./gradlew bootRun
+```text
+com.firstticket.queueservice
+├── domain              # 도메인 모델, VO, Enum, Repository 인터페이스
+├── application         # 유스케이스 (Service), Command / Query / Result DTO
+├── infrastructure      # Redis Repository, JWT 발급기, 스케줄러
+└── presentation        # REST Controller, Response DTO
 ```
 
-또는 IntelliJ에서 각 서비스를 순서대로 실행한다.
+---
 
-### 환경변수 설정
+## 🌐 API 엔드포인트
 
-queue-service 실행 시 다음 환경변수가 필요하다.
+| Method | Path | 설명 |
+| --- | --- | --- |
+| POST | `/api/v1/queues/programs/{programId}` | 대기열 진입 (대기 토큰 발급) |
+| GET | `/api/v1/queues/programs/{programId}` | 대기 / 입장 상태 조회 (폴링) |
+| DELETE | `/api/v1/queues/programs/{programId}` | 대기 취소 |
 
-```bash
-CONFIG_SERVER_USERNAME=admin
-CONFIG_SERVER_PASSWORD=admin1234
-SPRING_PROFILES_ACTIVE=local        # 선택, 기본값: local
-CONFIG_SERVER_URL=http://localhost:8888   # 선택, 기본값
-```
-
-`.env.example` 파일을 참고하여 `.env` 또는 IntelliJ Run Configuration에 설정한다.
+상세한 요청 / 응답 예시는 REST Docs 참조: `http://localhost:8085/docs/index.html`
 
 ---
 
@@ -76,22 +71,41 @@ CONFIG_SERVER_URL=http://localhost:8888   # 선택, 기본값
 
 ---
 
+## 🚀 로컬 실행
+
+### 사전 조건
+
+다음 인프라가 먼저 실행되어 있어야 한다.
+
+1. **infra 레포의 docker-compose** — Redis
+2. **config-server** — 설정 관리 서버
+3. **eureka-server** — 서비스 디스커버리
+
+### 환경변수 설정
+
+queue-service 실행 시 다음 환경변수가 필요하다.
+
+```bash
+CONFIG_SERVER_USERNAME=
+CONFIG_SERVER_PASSWORD=
+GITHUB_USER=
+GITHUB_TOKEN=
+```
+
+`.env.example` 파일을 참고하여 `.env` 를 작성한다.
+
+### 외부 설정
+
+JWT 비밀키 / 대기 토큰 TTL / 입장 승인 batchSize 등 운영 정책은 config-repo 의
+`queue-service.yml` 에서 관리된다.
+
+---
+
 ## 🔍 헬스체크
 
 ```bash
 curl http://localhost:8085/actuator/health
 # → {"status":"UP"}
-```
-
----
-
-## 📁 패키지 구조
-```text
-com.firstticket.queueservice
-├── domain          # 도메인 모델, VO, Enum
-├── application     # 유스케이스, 서비스
-├── infrastructure  # Redis, 외부 연동
-└── interfaces      # REST Controller, DTO
 ```
 
 ---

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -73,7 +73,7 @@ include::{snippets}/queue-token-get-not-found/response-fields.adoc[]
 
 == 대기 취소
 
-operation::queue-token-cancel[snippets='http-request,path-parameters,request-headers,http-response']
+operation::queue-token-cancel[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
 === 에러 응답
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -34,7 +34,7 @@
 
 === 인증 실패 (401)
 
-`Authorization` 헤더가 없거나 형식이 잘못된 경우 발생한다.
+`Authorization` 헤더가 없거나 토큰이 유효하지 않은 경우 발생한다.
 
 include::{snippets}/queue-token-unauthorized/http-response.adoc[]
 include::{snippets}/queue-token-unauthorized/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -10,10 +10,6 @@
 
 대기열 진입 / 조회 / 취소 API.
 
-=== 인증
-
-모든 API 는 Gateway 가 검증한 `X-User-Id` 헤더를 사용한다.
-
 === 응답 형식
 
 성공 / 실패 모두 `ApiResponse<T>` 형식으로 응답한다.
@@ -38,7 +34,7 @@
 
 === 인증 실패 (401)
 
-`X-User-Id` 헤더가 없거나 형식이 잘못된 경우 발생한다.
+`Authorization` 헤더가 없거나 형식이 잘못된 경우 발생한다.
 
 include::{snippets}/queue-token-unauthorized/http-response.adoc[]
 include::{snippets}/queue-token-unauthorized/response-fields.adoc[]

--- a/src/main/java/com/firstticket/queueservice/config/QueueProperties.java
+++ b/src/main/java/com/firstticket/queueservice/config/QueueProperties.java
@@ -16,14 +16,14 @@ import java.time.Duration;
 public record QueueProperties(
 
     /**
-     * 대기 토큰의 TTL
+     * 대기 토큰의 TTL.
      * 이 시간 내 입장 승인 못 받으면 자동 만료
      */
     @NotNull
     Duration waitingTtl,
 
     /**
-     * 한 번의 배치 스케줄러 실행 시 입장 승인할 인원 수
+     * 한 번의 배치 스케줄러 실행 시 입장 승인할 인원 수.
      */
     @Min(1)
     int admissionBatchSize

--- a/src/main/java/com/firstticket/queueservice/infrastructure/scheduler/AdmissionScheduler.java
+++ b/src/main/java/com/firstticket/queueservice/infrastructure/scheduler/AdmissionScheduler.java
@@ -79,6 +79,9 @@ public class AdmissionScheduler {
             return;
         }
 
+        log.info("[AdmissionScheduler] programId={} 의 {} 명을 admit 합니다",
+            programId.asString(), candidates.size());
+
         int successCount = 0;
         for (QueueToken queueToken : candidates) {
             try {

--- a/src/main/java/com/firstticket/queueservice/presentation/QueueSuccessCode.java
+++ b/src/main/java/com/firstticket/queueservice/presentation/QueueSuccessCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum QueueSuccessCode implements SuccessCode {
     QUEUE_TOKEN_ISSUED(HttpStatus.CREATED, "대기 토큰이 발급되었습니다"),
     QUEUE_TOKEN_FOUND(HttpStatus.OK, "대기 토큰을 조회했습니다"),
-    QUEUE_TOKEN_CANCELLED(HttpStatus.NO_CONTENT, "대기를 취소했습니다");
+    QUEUE_TOKEN_CANCELLED(HttpStatus.OK, "대기를 취소했습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/queueservice/presentation/QueueTokenController.java
+++ b/src/main/java/com/firstticket/queueservice/presentation/QueueTokenController.java
@@ -63,7 +63,7 @@ public class QueueTokenController {
     /**
      * 대기 취소.
      *
-     * @return 204 No Content
+     * @return 200 OK
      */
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> cancelToken(

--- a/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
+++ b/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
@@ -53,10 +53,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 테스트 통과 시 REST Docs snippet 이 자동 생성되며,
  * AsciiDoc 빌드를 거쳐 build/docs/asciidoc/index.html 로 문서화된다.
  *
+ * <p>인증 처리:
+ * <ul>
+ *   <li>실제 운영 환경에선 Gateway 가 Authorization Bearer 토큰 검증 후
+ *       사용자 ID 를 Filter 통해 ThreadLocal (AuthContext) 에 주입한다.</li>
+ *   <li>테스트에선 AuthContext.getUserId() 를 mockStatic 으로 직접 mock 하므로
+ *       실제 헤더는 의미 없다. 단, REST Docs 문서화를 위해 외부 클라이언트
+ *       시각의 Authorization 헤더를 dummy 값으로 보낸다.</li>
+ * </ul>
+ *
  * <p>주요 검증:
  * <ul>
  *   <li>HTTP 메서드별 정상 동작 (POST 201, GET 200, DELETE 204)</li>
- *   <li>인증 헤더 (X-User-Id) 누락 시 401</li>
+ *   <li>인증 실패 시 401</li>
  *   <li>도메인 예외 → HTTP status 매핑 (404, 400, 409)</li>
  * </ul>
  */
@@ -65,6 +74,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @Import(GlobalExceptionHandler.class)
 class QueueTokenControllerTest {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String DUMMY_BEARER_TOKEN = "Bearer dummy-access-token";
 
     @Autowired
     private MockMvc mockMvc;
@@ -90,31 +102,32 @@ class QueueTokenControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId)
-                    .header("X-User-Id", userId.toString()))
-                .andExpect(status().isCreated())
-                .andDo(document("queue-token-issue",
-                    preprocessRequest(
-                        prettyPrint(),
-                        modifyHeaders().remove("Content-Type")
-                    ),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("programId").description("프로그램 ID")
-                    ),
-                    requestHeaders(
-                        headerWithName("X-User-Id").description("Gateway 가 주입한 사용자 ID")
-                    ),
-                    responseFields(
-                        fieldWithPath("success").description("요청 성공 여부"),
-                        fieldWithPath("code").description("응답 코드"),
-                        fieldWithPath("message").description("응답 메시지"),
-                        fieldWithPath("timestamp").description("응답 시각"),
-                        fieldWithPath("data.tokenId").description("발급된 토큰 ID"),
-                        fieldWithPath("data.status").description("토큰 상태 (WAITING)"),
-                        fieldWithPath("data.issuedAt").description("발급 시각"),
-                        fieldWithPath("data.position").description("현재 순번")
-                    )
-                ));
+                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                    .andExpect(status().isCreated())
+                    .andDo(document("queue-token-issue",
+                            preprocessRequest(
+                                    prettyPrint(),
+                                    modifyHeaders().remove("Content-Type")
+                            ),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("programId").description("프로그램 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization")
+                                            .description("Bearer access token (Keycloak 발급)")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부"),
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각"),
+                                    fieldWithPath("data.tokenId").description("발급된 토큰 ID"),
+                                    fieldWithPath("data.status").description("토큰 상태 (WAITING)"),
+                                    fieldWithPath("data.issuedAt").description("발급 시각"),
+                                    fieldWithPath("data.position").description("현재 순번")
+                            )
+                    ));
         }
     }
 
@@ -134,28 +147,29 @@ class QueueTokenControllerTest {
 
             // when & then
             mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
-                    .header("X-User-Id", userId.toString()))
-                .andExpect(status().isOk())
-                .andDo(document("queue-token-get",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("programId").description("프로그램 ID")
-                    ),
-                    requestHeaders(
-                        headerWithName("X-User-Id").description("Gateway 가 주입한 사용자 ID")
-                    ),
-                    responseFields(
-                        fieldWithPath("success").description("요청 성공 여부"),
-                        fieldWithPath("code").description("응답 코드"),
-                        fieldWithPath("message").description("응답 메시지"),
-                        fieldWithPath("timestamp").description("응답 시각"),
-                        fieldWithPath("data.tokenId").description("토큰 ID"),
-                        fieldWithPath("data.status").description("토큰 상태 (WAITING / ADMITTED / EXPIRED)"),
-                        fieldWithPath("data.issuedAt").description("발급 시각"),
-                        fieldWithPath("data.position").description("현재 순번. ADMITTED 등 큐에서 빠진 상태면 null").optional()
-                    )
-                ));
+                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                    .andExpect(status().isOk())
+                    .andDo(document("queue-token-get",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("programId").description("프로그램 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization")
+                                            .description("Bearer access token (Keycloak 발급)")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부"),
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각"),
+                                    fieldWithPath("data.tokenId").description("토큰 ID"),
+                                    fieldWithPath("data.status").description("토큰 상태 (WAITING / ADMITTED / EXPIRED)"),
+                                    fieldWithPath("data.issuedAt").description("발급 시각"),
+                                    fieldWithPath("data.position").description("현재 순번. ADMITTED 등 큐에서 빠진 상태면 null").optional()
+                            )
+                    ));
         }
     }
 
@@ -173,49 +187,50 @@ class QueueTokenControllerTest {
 
             // when & then
             mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
-                    .header("X-User-Id", userId.toString()))
-                .andExpect(status().isNoContent())
-                .andDo(document("queue-token-cancel",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("programId").description("프로그램 ID")
-                    ),
-                    requestHeaders(
-                        headerWithName("X-User-Id").description("Gateway 가 주입한 사용자 ID")
-                    )
-                ));
+                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                    .andExpect(status().isNoContent())
+                    .andDo(document("queue-token-cancel",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("programId").description("프로그램 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization")
+                                            .description("Bearer access token (Keycloak 발급)")
+                            )
+                    ));
         }
     }
 
     // ===== 에러 케이스 =====
 
     @Test
-    @DisplayName("X-User-Id 헤더 없으면 401 Unauthorized")
+    @DisplayName("인증 실패 시 401 Unauthorized")
     void 인증_실패_401() throws Exception {
         // given
         UUID programId = UUID.randomUUID();
 
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId)
-                .thenThrow(new BusinessException(CommonErrorCode.UNAUTHORIZED));
+                    .thenThrow(new BusinessException(CommonErrorCode.UNAUTHORIZED));
 
             // when & then
             mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId))
-                .andExpect(status().isUnauthorized())
-                .andDo(document("queue-token-unauthorized",
-                    preprocessRequest(
-                        prettyPrint(),
-                        modifyHeaders().remove("Content-Type")
-                    ),
-                    preprocessResponse(prettyPrint()),
-                    responseFields(
-                        fieldWithPath("success").description("요청 성공 여부 (false)"),
-                        fieldWithPath("code").description("에러 코드 (UNAUTHORIZED)"),
-                        fieldWithPath("message").description("에러 메시지"),
-                        fieldWithPath("timestamp").description("응답 시각")
-                    )
-                ));
+                    .andExpect(status().isUnauthorized())
+                    .andDo(document("queue-token-unauthorized",
+                            preprocessRequest(
+                                    prettyPrint(),
+                                    modifyHeaders().remove("Content-Type")
+                            ),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
+                                    fieldWithPath("code").description("에러 코드 (UNAUTHORIZED)"),
+                                    fieldWithPath("message").description("에러 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각")
+                            )
+                    ));
         }
     }
 
@@ -232,21 +247,21 @@ class QueueTokenControllerTest {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
             mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId)
-                    .header("X-User-Id", userId.toString()))
-                .andExpect(status().isConflict())
-                .andDo(document("queue-token-duplicate",
-                    preprocessRequest(
-                        prettyPrint(),
-                        modifyHeaders().remove("Content-Type")
-                    ),
-                    preprocessResponse(prettyPrint()),
-                    responseFields(
-                        fieldWithPath("success").description("요청 성공 여부 (false)"),
-                        fieldWithPath("code").description("에러 코드 (DUPLICATE_TOKEN)"),
-                        fieldWithPath("message").description("에러 메시지"),
-                        fieldWithPath("timestamp").description("응답 시각")
-                    )
-                ));
+                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                    .andExpect(status().isConflict())
+                    .andDo(document("queue-token-duplicate",
+                            preprocessRequest(
+                                    prettyPrint(),
+                                    modifyHeaders().remove("Content-Type")
+                            ),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
+                                    fieldWithPath("code").description("에러 코드 (DUPLICATE_TOKEN)"),
+                                    fieldWithPath("message").description("에러 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각")
+                            )
+                    ));
         }
     }
 
@@ -264,18 +279,18 @@ class QueueTokenControllerTest {
 
             // when & then
             mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
-                    .header("X-User-Id", userId.toString()))
-                .andExpect(status().isNotFound())
-                .andDo(document("queue-token-get-not-found",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    responseFields(
-                        fieldWithPath("success").description("요청 성공 여부 (false)"),
-                        fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
-                        fieldWithPath("message").description("에러 메시지"),
-                        fieldWithPath("timestamp").description("응답 시각")
-                    )
-                ));
+                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                    .andExpect(status().isNotFound())
+                    .andDo(document("queue-token-get-not-found",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
+                                    fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
+                                    fieldWithPath("message").description("에러 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각")
+                            )
+                    ));
         }
     }
 
@@ -293,18 +308,18 @@ class QueueTokenControllerTest {
 
             // when & then
             mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
-                    .header("X-User-Id", userId.toString()))
-                .andExpect(status().isNotFound())
-                .andDo(document("queue-token-cancel-not-found",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    responseFields(
-                        fieldWithPath("success").description("요청 성공 여부 (false)"),
-                        fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
-                        fieldWithPath("message").description("에러 메시지"),
-                        fieldWithPath("timestamp").description("응답 시각")
-                    )
-                ));
+                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                    .andExpect(status().isNotFound())
+                    .andDo(document("queue-token-cancel-not-found",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
+                                    fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
+                                    fieldWithPath("message").description("에러 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각")
+                            )
+                    ));
         }
     }
 
@@ -322,18 +337,18 @@ class QueueTokenControllerTest {
 
             // when & then
             mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
-                    .header("X-User-Id", userId.toString()))
-                .andExpect(status().isBadRequest())
-                .andDo(document("queue-token-cancel-invalid-state",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    responseFields(
-                        fieldWithPath("success").description("요청 성공 여부 (false)"),
-                        fieldWithPath("code").description("에러 코드 (INVALID_TOKEN_STATE)"),
-                        fieldWithPath("message").description("에러 메시지"),
-                        fieldWithPath("timestamp").description("응답 시각")
-                    )
-                ));
+                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("queue-token-cancel-invalid-state",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
+                                    fieldWithPath("code").description("에러 코드 (INVALID_TOKEN_STATE)"),
+                                    fieldWithPath("message").description("에러 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각")
+                            )
+                    ));
         }
     }
 
@@ -355,28 +370,29 @@ class QueueTokenControllerTest {
 
             // when & then
             mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
-                    .header("X-User-Id", userId.toString()))
-                .andExpect(status().isOk())
-                .andDo(document("queue-token-get-admitted",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    pathParameters(
-                        parameterWithName("programId").description("프로그램 ID")
-                    ),
-                    requestHeaders(
-                        headerWithName("X-User-Id").description("Gateway 가 주입한 사용자 ID")
-                    ),
-                    responseFields(
-                        fieldWithPath("success").description("요청 성공 여부"),
-                        fieldWithPath("code").description("응답 코드"),
-                        fieldWithPath("message").description("응답 메시지"),
-                        fieldWithPath("timestamp").description("응답 시각"),
-                        fieldWithPath("data.tokenId").description("토큰 ID"),
-                        fieldWithPath("data.status").description("토큰 상태 (ADMITTED)"),
-                        fieldWithPath("data.issuedAt").description("발급 시각"),
-                        fieldWithPath("data.entryToken").description("입장 토큰 (JWT) — ADMITTED 상태일 때만 포함")
-                    )
-                ));
+                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                    .andExpect(status().isOk())
+                    .andDo(document("queue-token-get-admitted",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("programId").description("프로그램 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization")
+                                            .description("Bearer access token (Keycloak 발급)")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부"),
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각"),
+                                    fieldWithPath("data.tokenId").description("토큰 ID"),
+                                    fieldWithPath("data.status").description("토큰 상태 (ADMITTED)"),
+                                    fieldWithPath("data.issuedAt").description("발급 시각"),
+                                    fieldWithPath("data.entryToken").description("입장 토큰 (JWT) — ADMITTED 상태일 때만 포함")
+                            )
+                    ));
         }
     }
 }

--- a/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
+++ b/src/test/java/com/firstticket/queueservice/presentation/QueueTokenControllerTest.java
@@ -64,7 +64,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * <p>주요 검증:
  * <ul>
- *   <li>HTTP 메서드별 정상 동작 (POST 201, GET 200, DELETE 204)</li>
+ *   <li>HTTP 메서드별 정상 동작 (POST 201, GET 200, DELETE 200)</li>
  *   <li>인증 실패 시 401</li>
  *   <li>도메인 예외 → HTTP status 매핑 (404, 400, 409)</li>
  * </ul>
@@ -188,7 +188,7 @@ class QueueTokenControllerTest {
             // when & then
             mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
                             .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isNoContent())
+                    .andExpect(status().isOk())
                     .andDo(document("queue-token-cancel",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
@@ -198,6 +198,12 @@ class QueueTokenControllerTest {
                             requestHeaders(
                                     headerWithName("Authorization")
                                             .description("Bearer access token (Keycloak 발급)")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").description("요청 성공 여부"),
+                                    fieldWithPath("code").description("응답 코드 (QUEUE_TOKEN_CANCELLED)"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("timestamp").description("응답 시각")
                             )
                     ));
         }


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

queue-service 의 README / REST docs / 주석을 정리하고, 대기 취소 응답의 HTTP status를 200 OK 로 변경합니다.


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [x] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [x] docs     : 문서 수정
- [x] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README: 핵심 기능·큐 라이프사이클(배치 승인·JWT 입장 토큰), 기술 스택(jjwt 버전), DDD/헥사고널 구조, REST Docs 기반 API 엔드포인트 및 포트 표, 로컬 실행 지침(사전조건 Redis, 환경변수 템플릿) 및 운영 정책 위치 명시
  * 인증 문서: X-User-Id → Authorization 헤더 전환 및 관련 401 설명 업데이트
  * API 문서: 대기 취소 응답 필드 문서 추가

* **Bug Fixes**
  * 토큰 취소 응답 상태 코드: 204 → 200

* **Tests**
  * 컨트롤러 테스트 및 REST Docs: 인증 헤더와 기대응답/문서 스니펫 갱신

* **Chores**
  * 입장 스케줄러 로그 출력 강화
* **Style**
  * 일부 Javadoc 문장부호 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->