### PR TITLE
[feat][queue-service] Server-driven Adaptive Polling 도입

### DIFF
--- a/scripts/after.js
+++ b/scripts/after.js
@@ -1,0 +1,53 @@
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+export const options = {
+    stages: [
+        { duration: '30s', target: 3000 },
+        { duration: '2m30s', target: 3000 },
+        { duration: '10s', target: 0 },
+    ],
+};
+
+const PROGRAM_ID = '550e8400-e29b-41d4-a716-446655440000';
+const BASE_URL = 'http://localhost:8085';
+
+const userIdsByVU = {};
+
+export default function () {
+    if (!userIdsByVU[__VU]) {
+        userIdsByVU[__VU] = uuidv4();
+
+        http.post(
+            `${BASE_URL}/api/v1/queues/programs/${PROGRAM_ID}`,
+            null,
+            { headers: { 'X-User-Id': userIdsByVU[__VU] }, tags: { name: 'enqueue' } }
+        );
+    }
+
+    const userId = userIdsByVU[__VU];
+
+    const res = http.get(
+        `${BASE_URL}/api/v1/queues/programs/${PROGRAM_ID}`,
+        { headers: { 'X-User-Id': userId }, tags: { name: 'polling' } }
+    );
+
+    check(res, { 'polling 200': (r) => r.status === 200 });
+
+    // After: retryAfterMs 따라 동적 sleep
+    let sleepSec = 3;
+    if (res.status === 200) {
+        try {
+            const body = JSON.parse(res.body);
+            const retryAfterMs = body.data?.retryAfterMs;
+            if (retryAfterMs != null) {
+                sleepSec = retryAfterMs / 1000;
+            }
+        } catch (e) {
+            // 파싱 실패 시 기본값
+        }
+    }
+
+    sleep(sleepSec);
+}

--- a/scripts/before.js
+++ b/scripts/before.js
@@ -1,0 +1,43 @@
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+export const options = {
+    stages: [
+        { duration: '30s', target: 3000 },
+        { duration: '2m30s', target: 3000 },
+        { duration: '10s', target: 0 },
+    ],
+};
+
+const PROGRAM_ID = '550e8400-e29b-41d4-a716-446655440000';
+const BASE_URL = 'http://localhost:8085';
+
+// 각 VU 마다 고유 userId 유지
+const userIdsByVU = {};
+
+export default function () {
+    // 이 VU 의 userId (없으면 새로 만들고 enqueue)
+    if (!userIdsByVU[__VU]) {
+        userIdsByVU[__VU] = uuidv4();
+
+        // enqueue (한 번만)
+        http.post(
+            `${BASE_URL}/api/v1/queues/programs/${PROGRAM_ID}`,
+            null,
+            { headers: { 'X-User-Id': userIdsByVU[__VU] }, tags: { name: 'enqueue' } }
+        );
+    }
+
+    const userId = userIdsByVU[__VU];
+
+    // Polling
+    const res = http.get(
+        `${BASE_URL}/api/v1/queues/programs/${PROGRAM_ID}`,
+        { headers: { 'X-User-Id': userId }, tags: { name: 'polling' } }
+    );
+
+    check(res, { 'polling 200': (r) => r.status === 200 });
+
+    sleep(3);  // Before: 3초 고정
+}

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -25,10 +25,40 @@
     "tokenId": "...",
     "status": "WAITING",
     "issuedAt": "...",
-    "position": 50
+    "position": 50,
+    "retryAfterMs": 1000
   }
 }
 ----
+
+=== Adaptive Polling (`retryAfterMs`)
+
+대기 정보 응답에 포함되는 `retryAfterMs` 필드는 클라이언트가 다음 폴링까지 대기해야 할 시간(ms)을 서버가 권장하는 값이다.
+
+순번에 따라 차등 적용된다:
+
+[cols="1,1,2", options="header"]
+|===
+| 순번 구간 | 권장 간격 | 비고
+
+| ≤ 100 (임박)
+| 1,000ms
+| Jitter 없음 (빠른 알림 우선)
+
+| ≤ 1,000 (중간)
+| 5,000ms ± 300ms
+| Jitter 적용
+
+| ≤ 10,000 (멀리)
+| 15,000ms ± 500ms
+| Jitter 적용
+
+| > 10,000 (매우 멀리)
+| 30,000ms ± 4,000ms
+| Jitter 적용
+|===
+
+ADMITTED 등 큐에서 빠진 상태의 토큰 조회 시 `retryAfterMs` 는 응답에서 제외된다 (폴링 종료 신호).
 
 == 공통 에러 응답
 
@@ -58,7 +88,7 @@ operation::queue-token-get[snippets='http-request,path-parameters,request-header
 
 === ADMITTED 상태 응답
 
-큐에서 빠진 후 (입장 가능) 응답.
+큐에서 빠진 후 (입장 가능) 응답. `retryAfterMs` 는 포함되지 않으며 클라이언트는 폴링을 중단하고 `entryToken` 으로 입장한다.
 
 operation::queue-token-get-admitted[snippets='http-response,response-fields']
 

--- a/src/main/java/com/firstticket/queueservice/queuetoken/presentation/PollingIntervalPolicy.java
+++ b/src/main/java/com/firstticket/queueservice/queuetoken/presentation/PollingIntervalPolicy.java
@@ -1,0 +1,73 @@
+package com.firstticket.queueservice.queuetoken.presentation;
+
+import org.springframework.stereotype.Component;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * 사용자 순번에 따른 폴링 간격 결정 정책.
+ *
+ * <p>Server-driven Adaptive Polling 의 핵심 컴포넌트.
+ * 응답에 포함될 {@code retryAfterMs} 값을 계산한다.
+ *
+ * <h3>정책</h3>
+ * <ul>
+ *   <li>임박 (≤100명): 1초 (jitter 없음, 빠른 알림 우선)</li>
+ *   <li>중간 (≤1000명): 5초 ± 300ms</li>
+ *   <li>멀리 (≤10000명): 15초 ± 500ms</li>
+ *   <li>매우 멀리 (그 이상): 30초 ± 4초</li>
+ * </ul>
+ *
+ * <p>Jitter 적용으로 같은 구간 사용자들의 동시 요청 분산 (Thundering Herd 방지).
+ */
+@Component
+public class PollingIntervalPolicy {
+
+    private static final int IMMINENT_THRESHOLD = 100;
+    private static final int NEAR_THRESHOLD = 1000;
+    private static final int FAR_THRESHOLD = 10000;
+
+    private static final int IMMINENT_INTERVAL_MS = 1000;
+    private static final int NEAR_INTERVAL_MS = 5000;
+    private static final int FAR_INTERVAL_MS = 15000;
+    private static final int VERY_FAR_INTERVAL_MS = 30000;
+
+    private static final int NEAR_JITTER_MS = 300;
+    private static final int FAR_JITTER_MS = 500;
+    private static final int VERY_FAR_JITTER_MS = 4000;
+
+    /**
+     * 사용자 순번에 따른 다음 폴링 간격을 계산한다.
+     *
+     * @param position 1-based 순번. {@code null} 이면 큐에서 빠진 상태 (ADMITTED 등).
+     * @return 다음 폴링까지 대기 시간 (ms). {@code null} 이면 폴링 불필요.
+     */
+    public Integer nextRetryAfterMs(Long position) {
+        if (position == null) {
+            return null;
+        }
+
+        int interval;
+        int jitter;
+
+        if (position <= IMMINENT_THRESHOLD) {
+            interval = IMMINENT_INTERVAL_MS;
+            jitter = 0;
+        } else if (position <= NEAR_THRESHOLD) {
+            interval = NEAR_INTERVAL_MS;
+            jitter = NEAR_JITTER_MS;
+        } else if (position <= FAR_THRESHOLD) {
+            interval = FAR_INTERVAL_MS;
+            jitter = FAR_JITTER_MS;
+        } else {
+            interval = VERY_FAR_INTERVAL_MS;
+            jitter = VERY_FAR_JITTER_MS;
+        }
+
+        int jitterValue = jitter > 0
+            ? ThreadLocalRandom.current().nextInt(-jitter, jitter + 1)
+            : 0;
+
+        return interval + jitterValue;
+    }
+
+}

--- a/src/main/java/com/firstticket/queueservice/queuetoken/presentation/QueueTokenController.java
+++ b/src/main/java/com/firstticket/queueservice/queuetoken/presentation/QueueTokenController.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 public class QueueTokenController {
 
     private final QueueTokenService queueTokenService;
+    private final PollingIntervalPolicy pollingIntervalPolicy;
 
     /**
      * 대기열 진입.
@@ -38,9 +39,10 @@ public class QueueTokenController {
             programId
         );
         QueueTokenResult result = queueTokenService.issueToken(command);
+        Integer retryAfterMs = pollingIntervalPolicy.nextRetryAfterMs(result.position());
         return ApiResponse.success(
             QueueSuccessCode.QUEUE_TOKEN_ISSUED,
-            QueueTokenResponse.from(result)
+            QueueTokenResponse.from(result, retryAfterMs)
         );
     }
 
@@ -55,9 +57,11 @@ public class QueueTokenController {
     ) {
         GetQueueTokenQuery query = GetQueueTokenQuery.of(AuthContext.getUserId(), programId);
         QueueTokenResult result = queueTokenService.getToken(query);
+        Integer retryAfterMs = pollingIntervalPolicy.nextRetryAfterMs(result.position());
         return ApiResponse.success(
             QueueSuccessCode.QUEUE_TOKEN_FOUND,
-            QueueTokenResponse.from(result));
+            QueueTokenResponse.from(result, retryAfterMs)
+        );
     }
 
     /**

--- a/src/main/java/com/firstticket/queueservice/queuetoken/presentation/dto/QueueTokenResponse.java
+++ b/src/main/java/com/firstticket/queueservice/queuetoken/presentation/dto/QueueTokenResponse.java
@@ -11,15 +11,17 @@ public record QueueTokenResponse(
     String status,
     LocalDateTime issuedAt,
     Long position,
-    String entryToken
+    String entryToken,
+    Integer retryAfterMs
 ) {
-    public static QueueTokenResponse from(QueueTokenResult result) {
+    public static QueueTokenResponse from(QueueTokenResult result, Integer retryAfterMs) {
         return new QueueTokenResponse(
             result.tokenId().asString(),
             result.status().name(),
             result.issuedAt().value(),
             result.position(),
-            result.entryToken()
+            result.entryToken(),
+            retryAfterMs
         );
     }
 }

--- a/src/test/java/com/firstticket/queueservice/queuetoken/presentation/QueueTokenControllerTest.java
+++ b/src/test/java/com/firstticket/queueservice/queuetoken/presentation/QueueTokenControllerTest.java
@@ -12,7 +12,6 @@ import com.firstticket.queueservice.queuetoken.domain.exception.InvalidTokenStat
 import com.firstticket.queueservice.queuetoken.domain.exception.TokenNotFoundException;
 import com.firstticket.queueservice.queuetoken.domain.vo.ProgramId;
 import com.firstticket.queueservice.queuetoken.domain.vo.UserId;
-import com.firstticket.queueservice.queuetoken.presentation.QueueTokenController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -47,29 +46,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-/**
- * 대기열 API 통합 테스트.
- *
- * <p>WebMvcTest 슬라이스로 Controller 만 로드하고 Service 는 mock 한다.
- * 테스트 통과 시 REST Docs snippet 이 자동 생성되며,
- * AsciiDoc 빌드를 거쳐 build/docs/asciidoc/index.html 로 문서화된다.
- *
- * <p>인증 처리:
- * <ul>
- *   <li>실제 운영 환경에선 Gateway 가 Authorization Bearer 토큰 검증 후
- *       사용자 ID 를 Filter 통해 ThreadLocal (AuthContext) 에 주입한다.</li>
- *   <li>테스트에선 AuthContext.getUserId() 를 mockStatic 으로 직접 mock 하므로
- *       실제 헤더는 의미 없다. 단, REST Docs 문서화를 위해 외부 클라이언트
- *       시각의 Authorization 헤더를 dummy 값으로 보낸다.</li>
- * </ul>
- *
- * <p>주요 검증:
- * <ul>
- *   <li>HTTP 메서드별 정상 동작 (POST 201, GET 200, DELETE 200)</li>
- *   <li>인증 실패 시 401</li>
- *   <li>도메인 예외 → HTTP status 매핑 (404, 400, 409)</li>
- * </ul>
- */
 @WebMvcTest(QueueTokenController.class)
 @AutoConfigureRestDocs
 @ActiveProfiles("test")
@@ -85,6 +61,9 @@ class QueueTokenControllerTest {
     @MockitoBean
     private QueueTokenService queueTokenService;
 
+    @MockitoBean
+    private PollingIntervalPolicy pollingIntervalPolicy;  // ← 추가
+
     // ===== 성공 케이스 =====
 
     @Test
@@ -97,38 +76,39 @@ class QueueTokenControllerTest {
         QueueTokenResult result = QueueTokenResult.of(token, 1L);
 
         when(queueTokenService.issueToken(any())).thenReturn(result);
+        when(pollingIntervalPolicy.nextRetryAfterMs(1L)).thenReturn(1000);  // ← 추가
 
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
-            // when & then
             mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId)
-                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isCreated())
-                    .andDo(document("queue-token-issue",
-                            preprocessRequest(
-                                    prettyPrint(),
-                                    modifyHeaders().remove("Content-Type")
-                            ),
-                            preprocessResponse(prettyPrint()),
-                            pathParameters(
-                                    parameterWithName("programId").description("프로그램 ID")
-                            ),
-                            requestHeaders(
-                                    headerWithName("Authorization")
-                                            .description("Bearer access token (Keycloak 발급)")
-                            ),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부"),
-                                    fieldWithPath("code").description("응답 코드"),
-                                    fieldWithPath("message").description("응답 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각"),
-                                    fieldWithPath("data.tokenId").description("발급된 토큰 ID"),
-                                    fieldWithPath("data.status").description("토큰 상태 (WAITING)"),
-                                    fieldWithPath("data.issuedAt").description("발급 시각"),
-                                    fieldWithPath("data.position").description("현재 순번")
-                            )
-                    ));
+                    .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                .andExpect(status().isCreated())
+                .andDo(document("queue-token-issue",
+                    preprocessRequest(
+                        prettyPrint(),
+                        modifyHeaders().remove("Content-Type")
+                    ),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("programId").description("프로그램 ID")
+                    ),
+                    requestHeaders(
+                        headerWithName("Authorization")
+                            .description("Bearer access token (Keycloak 발급)")
+                    ),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부"),
+                        fieldWithPath("code").description("응답 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각"),
+                        fieldWithPath("data.tokenId").description("발급된 토큰 ID"),
+                        fieldWithPath("data.status").description("토큰 상태 (WAITING)"),
+                        fieldWithPath("data.issuedAt").description("발급 시각"),
+                        fieldWithPath("data.position").description("현재 순번"),
+                        fieldWithPath("data.retryAfterMs").description("다음 폴링까지 권장 대기 시간 (ms). 순번에 따라 차등 적용").optional()  // ← 추가
+                    )
+                ));
         }
     }
 
@@ -142,35 +122,36 @@ class QueueTokenControllerTest {
         QueueTokenResult result = QueueTokenResult.of(token, 50L);
 
         when(queueTokenService.getToken(any())).thenReturn(result);
+        when(pollingIntervalPolicy.nextRetryAfterMs(50L)).thenReturn(1000);  // ← 추가
 
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
-            // when & then
             mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
-                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isOk())
-                    .andDo(document("queue-token-get",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            pathParameters(
-                                    parameterWithName("programId").description("프로그램 ID")
-                            ),
-                            requestHeaders(
-                                    headerWithName("Authorization")
-                                            .description("Bearer access token (Keycloak 발급)")
-                            ),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부"),
-                                    fieldWithPath("code").description("응답 코드"),
-                                    fieldWithPath("message").description("응답 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각"),
-                                    fieldWithPath("data.tokenId").description("토큰 ID"),
-                                    fieldWithPath("data.status").description("토큰 상태 (WAITING / ADMITTED / EXPIRED)"),
-                                    fieldWithPath("data.issuedAt").description("발급 시각"),
-                                    fieldWithPath("data.position").description("현재 순번. ADMITTED 등 큐에서 빠진 상태면 null").optional()
-                            )
-                    ));
+                    .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("queue-token-get",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("programId").description("프로그램 ID")
+                    ),
+                    requestHeaders(
+                        headerWithName("Authorization")
+                            .description("Bearer access token (Keycloak 발급)")
+                    ),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부"),
+                        fieldWithPath("code").description("응답 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각"),
+                        fieldWithPath("data.tokenId").description("토큰 ID"),
+                        fieldWithPath("data.status").description("토큰 상태 (WAITING / ADMITTED / EXPIRED)"),
+                        fieldWithPath("data.issuedAt").description("발급 시각"),
+                        fieldWithPath("data.position").description("현재 순번. ADMITTED 등 큐에서 빠진 상태면 null").optional(),
+                        fieldWithPath("data.retryAfterMs").description("다음 폴링까지 권장 대기 시간 (ms). ADMITTED 상태면 null").optional()  // ← 추가
+                    )
+                ));
         }
     }
 
@@ -186,31 +167,31 @@ class QueueTokenControllerTest {
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
-            // when & then
             mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
-                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isOk())
-                    .andDo(document("queue-token-cancel",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            pathParameters(
-                                    parameterWithName("programId").description("프로그램 ID")
-                            ),
-                            requestHeaders(
-                                    headerWithName("Authorization")
-                                            .description("Bearer access token (Keycloak 발급)")
-                            ),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부"),
-                                    fieldWithPath("code").description("응답 코드 (QUEUE_TOKEN_CANCELLED)"),
-                                    fieldWithPath("message").description("응답 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각")
-                            )
-                    ));
+                    .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("queue-token-cancel",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("programId").description("프로그램 ID")
+                    ),
+                    requestHeaders(
+                        headerWithName("Authorization")
+                            .description("Bearer access token (Keycloak 발급)")
+                    ),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부"),
+                        fieldWithPath("code").description("응답 코드 (QUEUE_TOKEN_CANCELLED)"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
         }
     }
 
     // ===== 에러 케이스 =====
+    // (변경 없음 - 에러 응답엔 data 필드 없으니 그대로)
 
     @Test
     @DisplayName("인증 실패 시 401 Unauthorized")
@@ -220,31 +201,29 @@ class QueueTokenControllerTest {
 
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId)
-                    .thenThrow(new BusinessException(CommonErrorCode.UNAUTHORIZED));
+                .thenThrow(new BusinessException(CommonErrorCode.UNAUTHORIZED));
 
-            // when & then
             mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId))
-                    .andExpect(status().isUnauthorized())
-                    .andDo(document("queue-token-unauthorized",
-                            preprocessRequest(
-                                    prettyPrint(),
-                                    modifyHeaders().remove("Content-Type")
-                            ),
-                            preprocessResponse(prettyPrint()),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
-                                    fieldWithPath("code").description("에러 코드 (UNAUTHORIZED)"),
-                                    fieldWithPath("message").description("에러 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각")
-                            )
-                    ));
+                .andExpect(status().isUnauthorized())
+                .andDo(document("queue-token-unauthorized",
+                    preprocessRequest(
+                        prettyPrint(),
+                        modifyHeaders().remove("Content-Type")
+                    ),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (UNAUTHORIZED)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
         }
     }
 
     @Test
     @DisplayName("동시 진입 시 race — 409 Conflict")
     void 중복_진입_409() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
         UUID programId = UUID.randomUUID();
 
@@ -254,28 +233,27 @@ class QueueTokenControllerTest {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
             mockMvc.perform(post("/api/v1/queues/programs/{programId}", programId)
-                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isConflict())
-                    .andDo(document("queue-token-duplicate",
-                            preprocessRequest(
-                                    prettyPrint(),
-                                    modifyHeaders().remove("Content-Type")
-                            ),
-                            preprocessResponse(prettyPrint()),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
-                                    fieldWithPath("code").description("에러 코드 (DUPLICATE_TOKEN)"),
-                                    fieldWithPath("message").description("에러 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각")
-                            )
-                    ));
+                    .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                .andExpect(status().isConflict())
+                .andDo(document("queue-token-duplicate",
+                    preprocessRequest(
+                        prettyPrint(),
+                        modifyHeaders().remove("Content-Type")
+                    ),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (DUPLICATE_TOKEN)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
         }
     }
 
     @Test
     @DisplayName("토큰 없음 — 조회 시 404")
     void 토큰_없음_조회_404() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
         UUID programId = UUID.randomUUID();
 
@@ -284,27 +262,25 @@ class QueueTokenControllerTest {
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
-            // when & then
             mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
-                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isNotFound())
-                    .andDo(document("queue-token-get-not-found",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
-                                    fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
-                                    fieldWithPath("message").description("에러 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각")
-                            )
-                    ));
+                    .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                .andExpect(status().isNotFound())
+                .andDo(document("queue-token-get-not-found",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
         }
     }
 
     @Test
     @DisplayName("토큰 없음 — 취소 시 404")
     void 토큰_없음_취소_404() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
         UUID programId = UUID.randomUUID();
 
@@ -313,27 +289,25 @@ class QueueTokenControllerTest {
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
-            // when & then
             mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
-                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isNotFound())
-                    .andDo(document("queue-token-cancel-not-found",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
-                                    fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
-                                    fieldWithPath("message").description("에러 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각")
-                            )
-                    ));
+                    .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                .andExpect(status().isNotFound())
+                .andDo(document("queue-token-cancel-not-found",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (TOKEN_NOT_FOUND)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
         }
     }
 
     @Test
     @DisplayName("WAITING 이 아닌 상태 취소 시도 — 400")
     void 취소_불가_상태_400() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
         UUID programId = UUID.randomUUID();
 
@@ -342,20 +316,19 @@ class QueueTokenControllerTest {
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
-            // when & then
             mockMvc.perform(delete("/api/v1/queues/programs/{programId}", programId)
-                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isBadRequest())
-                    .andDo(document("queue-token-cancel-invalid-state",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부 (false)"),
-                                    fieldWithPath("code").description("에러 코드 (INVALID_TOKEN_STATE)"),
-                                    fieldWithPath("message").description("에러 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각")
-                            )
-                    ));
+                    .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                .andExpect(status().isBadRequest())
+                .andDo(document("queue-token-cancel-invalid-state",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부 (false)"),
+                        fieldWithPath("code").description("에러 코드 (INVALID_TOKEN_STATE)"),
+                        fieldWithPath("message").description("에러 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각")
+                    )
+                ));
         }
     }
 
@@ -371,35 +344,36 @@ class QueueTokenControllerTest {
         QueueTokenResult result = QueueTokenResult.of(token, null);   // position null
 
         when(queueTokenService.getToken(any())).thenReturn(result);
+        when(pollingIntervalPolicy.nextRetryAfterMs(null)).thenReturn(null);  // ← 추가 (ADMITTED니까 null)
 
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId).thenReturn(userId);
 
-            // when & then
             mockMvc.perform(get("/api/v1/queues/programs/{programId}", programId)
-                            .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
-                    .andExpect(status().isOk())
-                    .andDo(document("queue-token-get-admitted",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            pathParameters(
-                                    parameterWithName("programId").description("프로그램 ID")
-                            ),
-                            requestHeaders(
-                                    headerWithName("Authorization")
-                                            .description("Bearer access token (Keycloak 발급)")
-                            ),
-                            responseFields(
-                                    fieldWithPath("success").description("요청 성공 여부"),
-                                    fieldWithPath("code").description("응답 코드"),
-                                    fieldWithPath("message").description("응답 메시지"),
-                                    fieldWithPath("timestamp").description("응답 시각"),
-                                    fieldWithPath("data.tokenId").description("토큰 ID"),
-                                    fieldWithPath("data.status").description("토큰 상태 (ADMITTED)"),
-                                    fieldWithPath("data.issuedAt").description("발급 시각"),
-                                    fieldWithPath("data.entryToken").description("입장 토큰 (JWT) — ADMITTED 상태일 때만 포함")
-                            )
-                    ));
+                    .header(AUTHORIZATION_HEADER, DUMMY_BEARER_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("queue-token-get-admitted",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("programId").description("프로그램 ID")
+                    ),
+                    requestHeaders(
+                        headerWithName("Authorization")
+                            .description("Bearer access token (Keycloak 발급)")
+                    ),
+                    responseFields(
+                        fieldWithPath("success").description("요청 성공 여부"),
+                        fieldWithPath("code").description("응답 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("timestamp").description("응답 시각"),
+                        fieldWithPath("data.tokenId").description("토큰 ID"),
+                        fieldWithPath("data.status").description("토큰 상태 (ADMITTED)"),
+                        fieldWithPath("data.issuedAt").description("발급 시각"),
+                        fieldWithPath("data.entryToken").description("입장 토큰 (JWT) — ADMITTED 상태일 때만 포함")
+                        // retryAfterMs 는 null 이라 응답에 없음 → 명세 안 함
+                    )
+                ));
         }
     }
 }

--- a/src/test/java/com/firstticket/queueservice/queuetoken/presentation/QueueTokenControllerTest.java
+++ b/src/test/java/com/firstticket/queueservice/queuetoken/presentation/QueueTokenControllerTest.java
@@ -106,7 +106,7 @@ class QueueTokenControllerTest {
                         fieldWithPath("data.status").description("토큰 상태 (WAITING)"),
                         fieldWithPath("data.issuedAt").description("발급 시각"),
                         fieldWithPath("data.position").description("현재 순번"),
-                        fieldWithPath("data.retryAfterMs").description("다음 폴링까지 권장 대기 시간 (ms). 순번에 따라 차등 적용").optional()  // ← 추가
+                        fieldWithPath("data.retryAfterMs").description("다음 폴링까지 권장 대기 시간 (ms). 순번에 따라 차등 적용")
                     )
                 ));
         }
@@ -149,7 +149,7 @@ class QueueTokenControllerTest {
                         fieldWithPath("data.status").description("토큰 상태 (WAITING / ADMITTED / EXPIRED)"),
                         fieldWithPath("data.issuedAt").description("발급 시각"),
                         fieldWithPath("data.position").description("현재 순번. ADMITTED 등 큐에서 빠진 상태면 null").optional(),
-                        fieldWithPath("data.retryAfterMs").description("다음 폴링까지 권장 대기 시간 (ms). ADMITTED 상태면 null").optional()  // ← 추가
+                        fieldWithPath("data.retryAfterMs").description("다음 폴링까지 권장 대기 시간 (ms). ADMITTED 상태면 null").optional()
                     )
                 ));
         }
@@ -344,7 +344,7 @@ class QueueTokenControllerTest {
         QueueTokenResult result = QueueTokenResult.of(token, null);   // position null
 
         when(queueTokenService.getToken(any())).thenReturn(result);
-        when(pollingIntervalPolicy.nextRetryAfterMs(null)).thenReturn(null);  // ← 추가 (ADMITTED니까 null)
+        when(pollingIntervalPolicy.nextRetryAfterMs(null)).thenReturn(null);  // ADMITTED니까 null
 
         try (MockedStatic<AuthContext> mocked = mockStatic(AuthContext.class)) {
             mocked.when(AuthContext::getUserId).thenReturn(userId);


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

응답 DTO 에 `retryAfterMs` 필드를 추가하여 **Server-driven Adaptive Polling** 도입.
서버가 사용자 순번에 따라 폴링 간격을 동적으로 제어하여 1:N fan-out 구조의 대기열에서 폴링 부하를 효율적으로 분산.

- `PollingIntervalPolicy` 클래스 추가 (Presentation 레이어)
  - 순번별 차등 적용: 임박(1초) / 중간(5초) / 후순위(15초) / 최후순위(30초)
  - Jitter 적용으로 동시 요청 분산 (Thundering Herd 방지)
- `QueueTokenResponse` 에 `retryAfterMs` 필드 추가
- `QueueTokenController` 에서 Policy 주입 및 응답 생성
- 테스트 코드 + RestDocs 갱신
- k6 부하 테스트 스크립트 추가 (before / after 비교)


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
close #34 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)

### API 응답 변경

**Before**
```json
{
  "tokenId": "...",
  "status": "WAITING",
  "issuedAt": "...",
  "position": 234
}
```

**After**
```json
{
  "tokenId": "...",
  "status": "WAITING",
  "issuedAt": "...",
  "position": 234,
  "retryAfterMs": 5300
}
```

ADMITTED 등 큐에서 빠진 상태(position = null)에서는 `retryAfterMs = null` → `@JsonInclude(NON_NULL)` 로 응답에서 제외됨 (클라이언트 폴링 종료 신호).

### 부하 테스트 결과 (k6, Vuser 3000, Duration 3분)

| 지표 | Before | After | 개선율 |
| --- | --- | --- | --- |
| 폴링 TPS | 883.7/s | 588.3/s | **-33.5%** |
| 평균 응답시간 | 11.86ms | 3.95ms | **-66.7%** |
| p95 응답시간 | 28.37ms | 6.55ms | **-76.9%** |
| 에러율 | 0% | 0% | 유지 |

폴링 부하 1/3 감소, 응답시간 65% 이상 개선 확인.


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 대기열 응답에 `retryAfterMs` 필드 추가 - 서버가 권장하는 다음 폴링 대기 시간을 동적으로 제공합니다.
  * Adaptive Polling 방식 지원 - 대기 순번에 따라 폴링 간격이 자동으로 조정됩니다.

* **Documentation**
  * 대기 정보 응답 스펙 문서 업데이트 - 새로운 필드 및 폴링 권장 간격 가이드 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/first-ticket/queue-service/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->